### PR TITLE
역할 관리 및 직원 관리 UI 구현

### DIFF
--- a/lib/common/widgets/empty_state.dart
+++ b/lib/common/widgets/empty_state.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import '../../core/theme/app_theme.dart';
+import '../../core/utils/responsive_size.dart';
+
+class EmptyState extends StatelessWidget {
+  final IconData icon;
+  final String heading;
+  final String subtitle;
+  final String? buttonLabel;
+  final VoidCallback? onButtonTap;
+
+  const EmptyState({
+    super.key,
+    required this.icon,
+    required this.heading,
+    required this.subtitle,
+    this.buttonLabel,
+    this.onButtonTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final rs = ResponsiveSize.of(context);
+
+    return Center(
+      child: Padding(
+        padding: rs.px(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: rs.w(64), color: AppColors.textSecondary),
+            SizedBox(height: rs.h(16)),
+            Text(heading, style: AppTextStyles.titleMedium),
+            SizedBox(height: rs.h(8)),
+            Text(
+              subtitle,
+              style: AppTextStyles.caption,
+              textAlign: TextAlign.center,
+            ),
+            if (buttonLabel != null && onButtonTap != null) ...[
+              SizedBox(height: rs.h(32)),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: onButtonTap,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.darkBackground,
+                    foregroundColor: AppColors.white,
+                    elevation: 0,
+                    padding: rs.py(16),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: rs.radius(12),
+                    ),
+                  ),
+                  child: Text(buttonLabel!, style: AppTextStyles.buttonText),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/common/widgets/role_list_tile.dart
+++ b/lib/common/widgets/role_list_tile.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import '../../../core/theme/app_theme.dart';
-import '../../../core/utils/responsive_size.dart';
-import '../../../l10n/app_localizations.dart';
-import '../role_provider.dart';
+import '../../core/theme/app_theme.dart';
+import '../../core/utils/responsive_size.dart';
+import '../../l10n/app_localizations.dart';
+import '../../features/role/role_provider.dart';
 
 class RoleListTile extends StatelessWidget {
   final RoleModel role;

--- a/lib/core/router/route_path.dart
+++ b/lib/core/router/route_path.dart
@@ -24,3 +24,16 @@ abstract class MyPath {
   static const root = '/my';
   static const accounts = '/my/accounts';
 }
+
+abstract class RolePath {
+  static const root   = '/role';
+  static const detail = '/role/detail';
+  static const add    = '/role/add';
+}
+
+abstract class EmployeePath {
+  static const contractMethod = '/employee/add/contract-method';
+  static const contractUpload = '/employee/add/contract-upload';
+  static const contractViewer = '/employee/add/contract-viewer';
+  static const inviteCode     = '/employee/add/invite-code';
+}

--- a/lib/core/router/route_path.dart
+++ b/lib/core/router/route_path.dart
@@ -32,6 +32,9 @@ abstract class RolePath {
 }
 
 abstract class EmployeePath {
+  static const list           = '/employee';
+  static const detail         = '/employee/detail';
+  static const roleSelect     = '/employee/add/role-select';
   static const contractMethod = '/employee/add/contract-method';
   static const contractUpload = '/employee/add/contract-upload';
   static const contractViewer = '/employee/add/contract-viewer';

--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'route_path.dart';
 import 'routes/home_routes.dart';
 import 'routes/root_routes.dart';
+import 'routes/role_routes.dart';
+import 'routes/employee_routes.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
 
@@ -13,6 +15,8 @@ final routerProvider = Provider<GoRouter>((ref) {
     initialLocation: RoutePath.splash,
     routes: [
       ...rootRoutes,
+      ...roleRoutes,
+      ...employeeRoutes,
       homeShellRoute,
     ],
   );

--- a/lib/core/router/routes/employee_routes.dart
+++ b/lib/core/router/routes/employee_routes.dart
@@ -1,0 +1,47 @@
+import 'package:go_router/go_router.dart';
+import '../route_path.dart';
+import '../../../features/employee/employee_list_screen.dart';
+import '../../../features/employee/employee_detail_screen.dart';
+import '../../../features/employee/employee_role_select_screen.dart';
+import '../../../features/employee/add/contract_method_screen.dart';
+import '../../../features/employee/add/contract_upload_screen.dart';
+import '../../../features/employee/add/contract_viewer_screen.dart';
+import '../../../features/employee/add/invite_code_screen.dart';
+import '../../../features/employee/employee_provider.dart';
+
+final employeeRoutes = [
+  GoRoute(
+    path: EmployeePath.list,
+    builder: (context, state) => const EmployeeListScreen(),
+  ),
+  GoRoute(
+    path: EmployeePath.detail,
+    builder: (context, state) {
+      final employee = state.extra as EmployeeModel;
+      return EmployeeDetailScreen(employee: employee);
+    },
+  ),
+  GoRoute(
+    path: EmployeePath.roleSelect,
+    builder: (context, state) => const EmployeeRoleSelectScreen(),
+  ),
+  GoRoute(
+    path: EmployeePath.contractMethod,
+    builder: (context, state) => const ContractMethodScreen(),
+  ),
+  GoRoute(
+    path: EmployeePath.contractUpload,
+    builder: (context, state) => const ContractUploadScreen(),
+  ),
+  GoRoute(
+    path: EmployeePath.contractViewer,
+    builder: (context, state) {
+      final pdfPath = state.extra as String;
+      return ContractViewerScreen(pdfPath: pdfPath);
+    },
+  ),
+  GoRoute(
+    path: EmployeePath.inviteCode,
+    builder: (context, state) => const InviteCodeScreen(),
+  ),
+];

--- a/lib/core/router/routes/role_routes.dart
+++ b/lib/core/router/routes/role_routes.dart
@@ -1,0 +1,24 @@
+import 'package:go_router/go_router.dart';
+import '../route_path.dart';
+import '../../../features/role/role_list_screen.dart';
+import '../../../features/role/role_detail_screen.dart';
+import '../../../features/role/role_add_screen.dart';
+import '../../../features/role/role_provider.dart';
+
+final roleRoutes = [
+  GoRoute(
+    path: RolePath.root,
+    builder: (context, state) => const RoleListScreen(),
+  ),
+  GoRoute(
+    path: RolePath.detail,
+    builder: (context, state) {
+      final role = state.extra as RoleModel;
+      return RoleDetailScreen(role: role);
+    },
+  ),
+  GoRoute(
+    path: RolePath.add,
+    builder: (context, state) => const RoleAddScreen(),
+  ),
+];

--- a/lib/core/router/routes/root_routes.dart
+++ b/lib/core/router/routes/root_routes.dart
@@ -41,6 +41,9 @@ final rootRoutes = [
   ),
   GoRoute(
     path: RoutePath.accountVerification,
-    builder: (context, state) => const AccountVerificationScreen(),
+    builder: (context, state) {
+      final fromMyPage = state.extra as bool? ?? false;
+      return AccountVerificationScreen(fromMyPage: fromMyPage);
+    },
   ),
 ];

--- a/lib/features/account/account_list_provider.dart
+++ b/lib/features/account/account_list_provider.dart
@@ -32,6 +32,8 @@ abstract class _AccountApiPath {
 
 final accountListProvider =
 StateNotifierProvider<AccountListNotifier, AccountListState>((ref) {
+  // keepAlive로 라우트 변경 시에도 유지
+  ref.keepAlive();
   return AccountListNotifier(ref.read(dioProvider));
 });
 
@@ -45,6 +47,9 @@ class AccountListNotifier extends StateNotifier<AccountListState> {
   final Dio _dio;
 
   Future<void> fetch() async {
+    // Mock일 때 이미 데이터 있으면 재fetch 안 함
+    if (EnvConfig.isMock && state is AccountListStateLoaded) return;
+
     state = AccountListStateLoading();
     try {
       if (EnvConfig.isMock) {

--- a/lib/features/account/account_list_screen.dart
+++ b/lib/features/account/account_list_screen.dart
@@ -3,13 +3,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../common/widgets/primary_button.dart';
 import '../../common/widgets/tag_badge.dart';
 import '../../core/router/route_path.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/utils/responsive_size.dart';
 import '../../l10n/app_localizations.dart';
-import '../consent/consent_provider.dart';
 import '../my/user_provider.dart';
 import 'account_list_provider.dart';
 

--- a/lib/features/account/account_verification_screen.dart
+++ b/lib/features/account/account_verification_screen.dart
@@ -12,7 +12,12 @@ import '../consent/consent_provider.dart';
 import 'account_provider.dart';
 
 class AccountVerificationScreen extends ConsumerStatefulWidget {
-  const AccountVerificationScreen({super.key});
+  final bool fromMyPage;
+
+  const AccountVerificationScreen({
+    super.key,
+    this.fromMyPage = false,
+  });
 
   @override
   ConsumerState<AccountVerificationScreen> createState() =>
@@ -76,7 +81,12 @@ class _AccountVerificationScreenState
     ref.listen<AccountState>(accountProvider, (_, next) {
       switch (next) {
         case AccountStateSuccess():
-          context.go(HomePath.root);
+          if (widget.fromMyPage) {
+            context.pop(); // 마이페이지에서 온 경우 그냥 뒤로
+            context.pop(); // salary_consent까지 pop
+          } else {
+            context.go(HomePath.root); // 초기 플로우는 go 유지
+          }
         case AccountStateError(:final message):
           ScaffoldMessenger.of(context)
               .showSnackBar(SnackBar(content: Text(message)));

--- a/lib/features/consent/salary_consent_screen.dart
+++ b/lib/features/consent/salary_consent_screen.dart
@@ -21,7 +21,11 @@ class SalaryConsentScreen extends ConsumerWidget {
     ref.listen<ConsentState>(consentProvider, (_, next) {
       switch (next) {
         case ConsentStateSuccess():
-          context.push(RoutePath.accountVerification);
+          context.push(
+              RoutePath.accountVerification,
+              extra: fromMyPage,
+          );
+
         case ConsentStateError(:final message):
           ScaffoldMessenger.of(context)
               .showSnackBar(SnackBar(content: Text(message)));

--- a/lib/features/employee/add/contract_method_screen.dart
+++ b/lib/features/employee/add/contract_method_screen.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../../../core/router/route_path.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/responsive_size.dart';
+import '../../../l10n/app_localizations.dart';
+import '../widgets/contract_method_card.dart';
+
+class ContractMethodScreen extends StatelessWidget {
+  const ContractMethodScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final rs = ResponsiveSize.of(context);
+    final s = S.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(s.contractMethodTitle)),
+      body: Padding(
+        padding: rs.pxy(horizontal: 24, vertical: 24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(s.contractMethodHeading, style: AppTextStyles.titleMedium),
+            SizedBox(height: rs.h(24)),
+            // PDF 직접 업로드 (실제 플로우)
+            ContractMethodCard(
+              icon: Icons.upload_file_outlined,
+              label: s.contractMethodDirectLabel,
+              description: s.contractMethodDirectDesc,
+              onTap: () => context.push(EmployeePath.contractUpload),
+            ),
+            SizedBox(height: rs.h(12)),
+            // 템플릿 불러오기 (비활성)
+            ContractMethodCard(
+              icon: Icons.description_outlined,
+              label: s.contractMethodTemplateLabel,
+              description: s.contractMethodTemplateDesc,
+              isDisabled: true,
+              onTap: () {},
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/employee/add/contract_upload_screen.dart
+++ b/lib/features/employee/add/contract_upload_screen.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:file_picker/file_picker.dart';
+import '../../../core/router/route_path.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/responsive_size.dart';
+import '../../../common/widgets/primary_button.dart';
+import '../../../l10n/app_localizations.dart';
+
+final _selectedFileProvider =
+StateProvider<PlatformFile?>((ref) => null);
+
+class ContractUploadScreen extends ConsumerWidget {
+  const ContractUploadScreen({super.key});
+
+  Future<void> _pickFile(WidgetRef ref) async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['pdf'],
+    );
+    if (result != null) {
+      ref.read(_selectedFileProvider.notifier).state = result.files.first;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final rs = ResponsiveSize.of(context);
+    final s = S.of(context);
+    final selectedFile = ref.watch(_selectedFileProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(s.contractUploadTitle)),
+      body: Padding(
+        padding: rs.pxy(horizontal: 24, vertical: 24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(s.contractUploadHeading, style: AppTextStyles.titleMedium),
+            SizedBox(height: rs.h(8)),
+            Text(s.contractUploadSubtitle, style: AppTextStyles.caption),
+            SizedBox(height: rs.h(32)),
+            // 업로드
+            GestureDetector(
+              onTap: () => _pickFile(ref),
+              child: Container(
+                width: double.infinity,
+                height: rs.h(180),
+                decoration: BoxDecoration(
+                  color: AppColors.lightGray,
+                  borderRadius: rs.radius(12),
+                  border: Border.all(
+                    color: selectedFile != null
+                        ? AppColors.darkBackground
+                        : AppColors.borderGray,
+                    width: 1.5,
+                  ),
+                ),
+                child: selectedFile == null
+                    ? _buildUploadPlaceholder(context, rs, s)
+                    : _buildSelectedFile(context, rs, selectedFile),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: rs.pxy(horizontal: 24, vertical: 16),
+          child: PrimaryButton(
+            text: s.contractUploadNextButton,
+            enabled: selectedFile != null,
+            onPressed: () => context.push(
+              EmployeePath.contractViewer,
+              extra: selectedFile?.path ?? '',
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildUploadPlaceholder(
+      BuildContext context, ResponsiveSize rs, S s) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(Icons.upload_file_outlined,
+            size: rs.w(40), color: AppColors.textSecondary),
+        SizedBox(height: rs.h(12)),
+        Text(s.contractUploadButton,
+            style: AppTextStyles.label
+                .copyWith(color: AppColors.textSecondary)),
+      ],
+    );
+  }
+
+  Widget _buildSelectedFile(
+      BuildContext context, ResponsiveSize rs, PlatformFile file) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(Icons.picture_as_pdf_outlined,
+            size: rs.w(32), color: AppColors.darkBackground),
+        SizedBox(width: rs.w(12)),
+        Flexible(
+          child: Text(
+            file.name,
+            style: AppTextStyles.label,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/employee/add/contract_viewer_screen.dart
+++ b/lib/features/employee/add/contract_viewer_screen.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_pdfview/flutter_pdfview.dart';
+import 'package:go_router/go_router.dart';
+import '../../../core/router/route_path.dart';
+import '../../../core/utils/responsive_size.dart';
+import '../../../common/widgets/primary_button.dart';
+import '../../../l10n/app_localizations.dart';
+import '../employee_provider.dart';
+
+class ContractViewerScreen extends ConsumerWidget {
+  final String pdfPath;
+
+  const ContractViewerScreen({super.key, required this.pdfPath});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final rs = ResponsiveSize.of(context);
+    final s = S.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(s.contractViewerTitle)),
+      body: PDFView(
+        filePath: pdfPath,
+        enableSwipe: true,
+        swipeHorizontal: false,
+        autoSpacing: true,
+        pageSnap: false,
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: rs.pxy(horizontal: 24, vertical: 16),
+          child: PrimaryButton(
+            text: s.contractViewerConfirmButton,
+            onPressed: () async {
+              await ref.read(inviteCodeProvider.notifier).generate();
+              if (context.mounted) {
+                context.push(EmployeePath.inviteCode);
+              }
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/employee/add/invite_code_screen.dart
+++ b/lib/features/employee/add/invite_code_screen.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import 'package:share_plus/share_plus.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/responsive_size.dart';
+import '../../../common/widgets/primary_button.dart';
+import '../../../l10n/app_localizations.dart';
+import '../employee_provider.dart';
+
+class InviteCodeScreen extends ConsumerWidget {
+  const InviteCodeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final rs = ResponsiveSize.of(context);
+    final s = S.of(context);
+    final inviteAsync = ref.watch(inviteCodeProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(s.inviteCodeTitle)),
+      body: inviteAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Text(s.networkError, style: AppTextStyles.body),
+        ),
+        data: (invite) {
+          if (invite == null) return const SizedBox.shrink();
+          return _buildContent(context, ref, rs, s, invite.code);
+        },
+      ),
+    );
+  }
+
+  Widget _buildContent(
+      BuildContext context,
+      WidgetRef ref,
+      ResponsiveSize rs,
+      S s,
+      String code,
+      ) {
+    return SingleChildScrollView(
+      padding: rs.pxy(horizontal: 24, vertical: 32),
+      child: Column(
+        children: [
+          Text(s.inviteCodeHeading, style: AppTextStyles.titleLarge),
+          SizedBox(height: rs.h(8)),
+          Text(
+            s.inviteCodeSubtitle,
+            style: AppTextStyles.caption,
+            textAlign: TextAlign.center,
+          ),
+          SizedBox(height: rs.h(32)),
+          QrImageView(
+            data: code,
+            version: QrVersions.auto,
+            size: rs.w(180),
+          ),
+          SizedBox(height: rs.h(24)),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(code, style: AppTextStyles.titleLarge),
+              SizedBox(width: rs.w(8)),
+              IconButton(
+                icon: Icon(
+                  Icons.copy_outlined,
+                  size: rs.w(20),
+                  color: AppColors.textSecondary,
+                ),
+                onPressed: () async {
+                  await Clipboard.setData(ClipboardData(text: code));
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(s.inviteCodeCopied)),
+                    );
+                  }
+                },
+              ),
+            ],
+          ),
+          SizedBox(height: rs.h(32)),
+          const Divider(color: AppColors.borderGray),
+          SizedBox(height: rs.h(24)),
+          _buildKakaoShareButton(rs, code, s),
+          SizedBox(height: rs.h(24)),
+          PrimaryButton(
+            text: s.inviteCodeDoneButton,
+            onPressed: () => context.go('/home'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildKakaoShareButton(ResponsiveSize rs, String code, S s) {
+    return GestureDetector(
+      onTap: () {
+        // TODO: 카카오 SDK 공유 연동
+        Share.share(code);
+      },
+      child: Container(
+        width: double.infinity,
+        height: rs.h(56),
+        decoration: BoxDecoration(
+          color: const Color(0xFFFEE500),
+          borderRadius: rs.radius(12),
+        ),
+        child: Center(
+          child: Text(
+            s.inviteCodeShareKakaoButton,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: Color(0xFF191919),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/employee/employee_detail_screen.dart
+++ b/lib/features/employee/employee_detail_screen.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../core/theme/app_theme.dart';
+import '../../core/utils/responsive_size.dart';
+import '../../l10n/app_localizations.dart';
+import 'employee_provider.dart';
+import 'widgets/role_change_sheet.dart';
+
+class EmployeeDetailScreen extends ConsumerWidget {
+  final EmployeeModel employee;
+
+  const EmployeeDetailScreen({super.key, required this.employee});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 목록에서 실시간 상태 반영
+    final employees = ref.watch(employeeListProvider).valueOrNull ?? [];
+    final current = employees.firstWhere(
+          (e) => e.id == employee.id,
+      orElse: () => employee,
+    );
+
+    final rs = ResponsiveSize.of(context);
+    final s = S.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(s.employeeDetailTitle)),
+      body: ListView(
+        children: [
+          _buildProfile(context, rs, current),
+          const Divider(height: 1, color: AppColors.borderGray),
+          _buildInfoSection(context, rs, s, current),
+          const Divider(height: 8, color: AppColors.lightGray),
+          _buildActionSection(context, ref, rs, s, current),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProfile(
+      BuildContext context, ResponsiveSize rs, EmployeeModel employee) {
+    return Padding(
+      padding: rs.pxy(horizontal: 24, vertical: 32),
+      child: Column(
+        children: [
+          CircleAvatar(
+            radius: rs.w(36),
+            backgroundColor: AppColors.lightGray,
+            child: Text(
+              employee.name.characters.first,
+              style: AppTextStyles.titleLarge,
+            ),
+          ),
+          SizedBox(height: rs.h(12)),
+          Text(employee.name, style: AppTextStyles.titleMedium),
+          SizedBox(height: rs.h(4)),
+          Text(employee.role.name, style: AppTextStyles.caption),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoSection(
+      BuildContext context,
+      ResponsiveSize rs,
+      S s,
+      EmployeeModel employee,
+      ) {
+    return Padding(
+      padding: rs.pxy(horizontal: 24, vertical: 20),
+      child: Column(
+        children: [
+          _buildInfoRow(
+            context,
+            rs,
+            label: s.employeeRoleLabel,
+            value: employee.role.name,
+          ),
+          SizedBox(height: rs.h(16)),
+          _buildInfoRow(
+            context,
+            rs,
+            label: s.employeeStartDateLabel,
+            value: employee.startDate,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(
+      BuildContext context,
+      ResponsiveSize rs, {
+        required String label,
+        required String value,
+      }) {
+    return Row(
+      children: [
+        Expanded(
+          flex: 2,
+          child: Text(label,
+              style: AppTextStyles.caption),
+        ),
+        Expanded(
+          flex: 3,
+          child: Text(value, style: AppTextStyles.body),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildActionSection(
+      BuildContext context,
+      WidgetRef ref,
+      ResponsiveSize rs,
+      S s,
+      EmployeeModel employee,
+      ) {
+    return Column(
+      children: [
+        // 역할 변경
+        _buildActionTile(
+          context,
+          rs,
+          label: s.employeeRoleChangeButton,
+          onTap: () => showModalBottomSheet(
+            context: context,
+            isScrollControlled: true,
+            backgroundColor: Colors.transparent,
+            builder: (_) => RoleChangeSheet(employee: employee),
+          ),
+        ),
+        const Divider(height: 1, color: AppColors.borderGray),
+        // 근로계약서 수정 요청 - 비활성화
+        _buildActionTile(
+          context,
+          rs,
+          label: s.employeeContractRequestButton,
+          onTap: () {
+          },
+        ),
+        const Divider(height: 1, color: AppColors.borderGray),
+        // 퇴직 처리
+        _buildActionTile(
+          context,
+          rs,
+          label: s.employeeResignButton,
+          textColor: AppColors.error,
+          onTap: () => _showResignDialog(context, ref, rs, s, employee),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildActionTile(
+      BuildContext context,
+      ResponsiveSize rs, {
+        required String label,
+        required VoidCallback onTap,
+        Color? textColor,
+      }) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: rs.pxy(horizontal: 24, vertical: 20),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                label,
+                style: AppTextStyles.body.copyWith(
+                  color: textColor ?? AppColors.textPrimary,
+                ),
+              ),
+            ),
+            Icon(Icons.chevron_right,
+                color: AppColors.textSecondary, size: rs.w(24)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showResignDialog(
+      BuildContext context,
+      WidgetRef ref,
+      ResponsiveSize rs,
+      S s,
+      EmployeeModel employee,
+      ) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: rs.radius(16)),
+        title: Text(s.employeeResignDialogTitle),
+        content: Text(
+          s.employeeResignDialogMessage,
+          style: AppTextStyles.caption,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => ctx.pop(),
+            child: Text(s.cancelButton,
+                style: AppTextStyles.body
+                    .copyWith(color: AppColors.textSecondary)),
+          ),
+          TextButton(
+            onPressed: () {
+              ref
+                  .read(employeeListProvider.notifier)
+                  .resignEmployee(employee.id);
+              ctx.pop();
+              context.pop();
+            },
+            child: Text(s.employeeResignButton,
+                style: AppTextStyles.body.copyWith(color: AppColors.error)),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/employee/employee_list_screen.dart
+++ b/lib/features/employee/employee_list_screen.dart
@@ -6,29 +6,29 @@ import '../../core/theme/app_theme.dart';
 import '../../core/utils/responsive_size.dart';
 import '../../common/widgets/empty_state.dart';
 import '../../l10n/app_localizations.dart';
-import 'role_provider.dart';
-import '../../common/widgets/role_list_tile.dart';
+import 'employee_provider.dart';
+import 'widgets/employee_list_tile.dart';
 
-class RoleListScreen extends ConsumerWidget {
-  const RoleListScreen({super.key});
+class EmployeeListScreen extends ConsumerWidget {
+  const EmployeeListScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final rolesAsync = ref.watch(roleListProvider);
+    final employeesAsync = ref.watch(employeeListProvider);
     final rs = ResponsiveSize.of(context);
     final s = S.of(context);
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(s.roleManagementTitle),
+        title: Text(s.employeeManagementTitle),
         actions: [
           IconButton(
             icon: const Icon(Icons.add),
-            onPressed: () => context.push(RolePath.add),
+            onPressed: () => context.push(EmployeePath.roleSelect),
           ),
         ],
       ),
-      body: rolesAsync.when(
+      body: employeesAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(
           child: Column(
@@ -38,29 +38,32 @@ class RoleListScreen extends ConsumerWidget {
               SizedBox(height: rs.h(12)),
               TextButton(
                 onPressed: () =>
-                    ref.read(roleListProvider.notifier).fetch(refresh: true),
+                    ref.read(employeeListProvider.notifier).fetch(refresh: true),
                 child: Text(s.retryButton),
               ),
             ],
           ),
         ),
-        data: (roles) => roles.isEmpty
+        data: (employees) => employees.isEmpty
             ? EmptyState(
-          icon: Icons.manage_accounts_outlined,
-          heading: s.roleEmptyStateHeading,
-          subtitle: s.roleEmptyStateSubtitle,
-          buttonLabel: s.roleEmptyStateButton,
-          onButtonTap: () => context.push(RolePath.add),
+          icon: Icons.people_outline,
+          heading: s.employeeListEmptyHeading,
+          subtitle: s.employeeListEmptySubtitle,
+          buttonLabel: s.employeeAddMenuLabel,
+          onButtonTap: () => context.push(EmployeePath.roleSelect),
         )
             : ListView.separated(
-          itemCount: roles.length,
+          itemCount: employees.length,
           separatorBuilder: (_, __) =>
           const Divider(height: 1, color: AppColors.borderGray),
           itemBuilder: (context, index) {
-            final role = roles[index];
-            return RoleListTile(
-              role: role,
-              onTap: () => context.push(RolePath.detail, extra: role),
+            final employee = employees[index];
+            return EmployeeListTile(
+              employee: employee,
+              onTap: () => context.push(
+                EmployeePath.detail,
+                extra: employee,
+              ),
             );
           },
         ),

--- a/lib/features/employee/employee_provider.dart
+++ b/lib/features/employee/employee_provider.dart
@@ -1,0 +1,146 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../role/role_provider.dart';
+
+// 모델
+
+enum EmployeeStatus { active, resigned }
+
+class EmployeeModel {
+  const EmployeeModel({
+    required this.id,
+    required this.name,
+    required this.role,
+    required this.startDate,
+    required this.status,
+  });
+
+  final String id;
+  final String name;
+  final RoleModel role;
+  final String startDate;
+  final EmployeeStatus status;
+
+  EmployeeModel copyWith({
+    String? id,
+    String? name,
+    RoleModel? role,
+    String? startDate,
+    EmployeeStatus? status,
+  }) =>
+      EmployeeModel(
+        id: id ?? this.id,
+        name: name ?? this.name,
+        role: role ?? this.role,
+        startDate: startDate ?? this.startDate,
+        status: status ?? this.status,
+      );
+
+  factory EmployeeModel.fromJson(Map<String, dynamic> json,
+      {required RoleModel role}) =>
+      EmployeeModel(
+        id: json['id'] as String,
+        name: json['name'] as String,
+        role: role,
+        startDate: json['startDate'] as String,
+        status: json['status'] == 'resigned'
+            ? EmployeeStatus.resigned
+            : EmployeeStatus.active,
+      );
+}
+
+class InviteCodeModel {
+  const InviteCodeModel({required this.code});
+  final String code;
+}
+
+// Mock
+
+final _mockManagerRole = RoleModel(
+  id: 1,
+  name: '매니저',
+  description: 'manager',
+  permissions: ['staff_manage', 'store_manage', 'contract_manage',
+    'salary_manage', 'staff_invite'],
+);
+
+final _mockEmployees = [
+  EmployeeModel(
+    id: 'emp_001',
+    name: '김민수',
+    role: _mockManagerRole,
+    startDate: '2024.01.01',
+    status: EmployeeStatus.active,
+  ),
+  EmployeeModel(
+    id: 'emp_002',
+    name: '박지영',
+    role: RoleModel(
+      id: 2,
+      name: '파트타이머',
+      description: 'partTimer',
+      permissions: ['store_manage'],
+    ),
+    startDate: '2024.03.15',
+    status: EmployeeStatus.active,
+  ),
+];
+
+// 직원 목록 Provider
+// TODO: API 연동 시 교체
+
+final employeeListProvider =
+StateNotifierProvider<EmployeeListNotifier, AsyncValue<List<EmployeeModel>>>(
+        (ref) => EmployeeListNotifier());
+
+class EmployeeListNotifier
+    extends StateNotifier<AsyncValue<List<EmployeeModel>>> {
+  EmployeeListNotifier() : super(const AsyncLoading()) {
+    fetch();
+  }
+
+  Future<void> fetch({bool refresh = false}) async {
+    state = const AsyncLoading();
+    await Future.delayed(const Duration(milliseconds: 300));
+
+    state = AsyncData(List.from(_mockEmployees));
+  }
+
+  void addEmployee(EmployeeModel employee) {
+    final current = state.valueOrNull ?? [];
+    state = AsyncData([...current, employee]);
+  }
+
+  void updateEmployeeRole(String employeeId, RoleModel newRole) {
+    final current = state.valueOrNull ?? [];
+    state = AsyncData(current
+        .map((e) => e.id == employeeId ? e.copyWith(role: newRole) : e)
+        .toList());
+  }
+
+  void resignEmployee(String employeeId) {
+    final current = state.valueOrNull ?? [];
+    state = AsyncData(current
+        .map((e) => e.id == employeeId
+        ? e.copyWith(status: EmployeeStatus.resigned)
+        : e)
+        .toList());
+  }
+}
+
+// 초대코드 Provider
+
+final inviteCodeProvider =
+StateNotifierProvider<InviteCodeNotifier, AsyncValue<InviteCodeModel?>>(
+        (ref) => InviteCodeNotifier());
+
+class InviteCodeNotifier
+    extends StateNotifier<AsyncValue<InviteCodeModel?>> {
+  InviteCodeNotifier() : super(const AsyncData(null));
+
+  Future<void> generate() async {
+    state = const AsyncLoading();
+    await Future.delayed(const Duration(milliseconds: 500));
+    // TODO: API 연동 시 교체
+    state = const AsyncData(InviteCodeModel(code: 'AB12-CD34'));
+  }
+}

--- a/lib/features/employee/employee_role_select_screen.dart
+++ b/lib/features/employee/employee_role_select_screen.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../core/router/route_path.dart';
+import '../../core/theme/app_theme.dart';
+import '../../core/utils/responsive_size.dart';
+import '../../l10n/app_localizations.dart';
+import '../role/role_provider.dart';
+import '../../common/widgets/role_list_tile.dart';
+
+class EmployeeRoleSelectScreen extends ConsumerStatefulWidget {
+  const EmployeeRoleSelectScreen({super.key});
+
+  @override
+  ConsumerState<EmployeeRoleSelectScreen> createState() =>
+      _EmployeeRoleSelectScreenState();
+}
+
+class _EmployeeRoleSelectScreenState
+    extends ConsumerState<EmployeeRoleSelectScreen> {
+  final _searchController = TextEditingController();
+  String _searchQuery = '';
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rolesAsync = ref.watch(roleListProvider);
+    final rs = ResponsiveSize.of(context);
+    final s = S.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(s.employeeRoleSelectTitle)),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 검색창
+          Padding(
+            padding: rs.pxy(horizontal: 24, vertical: 16),
+            child: TextField(
+              controller: _searchController,
+              onChanged: (v) => setState(() => _searchQuery = v.trim()),
+              decoration: AppInputDecorations.outlined(
+                hintText: s.employeeRoleSelectSearchHint,
+              ).copyWith(
+                prefixIcon: const Icon(Icons.search, color: AppColors.textSecondary),
+                suffixIcon: _searchQuery.isNotEmpty
+                    ? IconButton(
+                  icon: const Icon(Icons.clear, color: AppColors.textSecondary),
+                  onPressed: () {
+                    _searchController.clear();
+                    setState(() => _searchQuery = '');
+                  },
+                )
+                    : null,
+              ),
+            ),
+          ),
+          const Divider(height: 1, color: AppColors.borderGray),
+          // 역할 목록
+          Expanded(
+            child: rolesAsync.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Center(
+                child: TextButton(
+                  onPressed: () =>
+                      ref.read(roleListProvider.notifier).fetch(refresh: true),
+                  child: Text(s.retryButton),
+                ),
+              ),
+              data: (roles) {
+                final filtered = _searchQuery.isEmpty
+                    ? roles
+                    : roles
+                    .where((r) => r.name
+                    .toLowerCase()
+                    .contains(_searchQuery.toLowerCase()))
+                    .toList();
+
+                return ListView(
+                  children: [
+                    if (filtered.isEmpty)
+                      Padding(
+                        padding: rs.pxy(horizontal: 24, vertical: 32),
+                        child: Center(
+                          child: Text(s.employeeRoleSelectEmpty,
+                              style: AppTextStyles.caption),
+                        ),
+                      )
+                    else
+                      ...filtered.map((role) => Column(
+                        children: [
+                          RoleListTile(
+                            role: role,
+                            onTap: () => context.push(
+                              EmployeePath.contractMethod,
+                              extra: role,
+                            ),
+                          ),
+                          const Divider(height: 1, color: AppColors.borderGray),
+                        ],
+                      )),
+                    const Divider(height: 1, color: AppColors.borderGray),
+                    // 새 역할 만들기 진입점
+                    _buildCreateRoleTile(context, rs, s),
+                  ],
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCreateRoleTile(
+      BuildContext context, ResponsiveSize rs, S s) {
+    return InkWell(
+      onTap: () async {
+        // 역할 추가 화면으로 이동 후 돌아오면 목록 갱신
+        await context.push(RolePath.add);
+        if (context.mounted) {
+          ref.read(roleListProvider.notifier).fetch(refresh: true);
+        }
+      },
+      child: Padding(
+        padding: rs.pxy(horizontal: 24, vertical: 20),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    s.employeeRoleSelectNoRole,
+                    style: AppTextStyles.caption,
+                  ),
+                  SizedBox(height: rs.h(4)),
+                  Text(
+                    s.employeeRoleSelectCreateButton,
+                    style: AppTextStyles.body.copyWith(
+                      color: AppColors.darkBackground,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Icon(Icons.add_circle_outline,
+                color: AppColors.darkBackground, size: rs.w(24)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/employee/widgets/contract_method_card.dart
+++ b/lib/features/employee/widgets/contract_method_card.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/responsive_size.dart';
+
+class ContractMethodCard extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String description;
+  final bool isDisabled;
+  final VoidCallback onTap;
+
+  const ContractMethodCard({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.description,
+    required this.onTap,
+    this.isDisabled = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final rs = ResponsiveSize.of(context);
+
+    return InkWell(
+      onTap: isDisabled ? null : onTap,
+      borderRadius: rs.radius(12),
+      child: Opacity(
+        opacity: isDisabled ? 0.45 : 1.0,
+        child: Container(
+          width: double.infinity,
+          padding: rs.pxy(horizontal: 20, vertical: 20),
+          decoration: BoxDecoration(
+            color: AppColors.lightGray,
+            borderRadius: rs.radius(12),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: rs.w(48),
+                height: rs.w(48),
+                decoration: BoxDecoration(
+                  color: AppColors.white,
+                  borderRadius: rs.radius(10),
+                ),
+                child: Icon(icon,
+                    size: rs.w(24), color: AppColors.textPrimary),
+              ),
+              SizedBox(width: rs.w(16)),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(label, style: AppTextStyles.titleMedium),
+                    SizedBox(height: rs.h(4)),
+                    Text(description, style: AppTextStyles.caption),
+                  ],
+                ),
+              ),
+              Icon(Icons.chevron_right,
+                  color: AppColors.textSecondary, size: rs.w(24)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/employee/widgets/employee_list_tile.dart
+++ b/lib/features/employee/widgets/employee_list_tile.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/responsive_size.dart';
+import '../employee_provider.dart';
+
+class EmployeeListTile extends StatelessWidget {
+  final EmployeeModel employee;
+  final VoidCallback onTap;
+
+  const EmployeeListTile({
+    super.key,
+    required this.employee,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final rs = ResponsiveSize.of(context);
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: rs.pxy(horizontal: 24, vertical: 16),
+        child: Row(
+          children: [
+            // 아바타
+            CircleAvatar(
+              radius: rs.w(20),
+              backgroundColor: AppColors.lightGray,
+              child: Text(
+                employee.name.characters.first,
+                style: AppTextStyles.titleMedium,
+              ),
+            ),
+            SizedBox(width: rs.w(12)),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(employee.name, style: AppTextStyles.titleMedium),
+                  SizedBox(height: rs.h(2)),
+                  Text(
+                    employee.role.name,
+                    style: AppTextStyles.caption,
+                  ),
+                ],
+              ),
+            ),
+            Icon(
+              Icons.chevron_right,
+              color: AppColors.textSecondary,
+              size: rs.w(24),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/employee/widgets/role_change_sheet.dart
+++ b/lib/features/employee/widgets/role_change_sheet.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/responsive_size.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../role/role_provider.dart';
+import '../employee_provider.dart';
+
+class RoleChangeSheet extends ConsumerWidget {
+  final EmployeeModel employee;
+
+  const RoleChangeSheet({super.key, required this.employee});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final rs = ResponsiveSize.of(context);
+    final s = S.of(context);
+    final rolesAsync = ref.watch(roleListProvider);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(rs.w(20))),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // 핸들
+          SizedBox(height: rs.h(12)),
+          Container(
+            width: rs.w(40),
+            height: rs.h(4),
+            decoration: BoxDecoration(
+              color: AppColors.borderGray,
+              borderRadius: rs.radius(2),
+            ),
+          ),
+          SizedBox(height: rs.h(20)),
+          Padding(
+            padding: rs.px(24),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(s.employeeRoleChangeTitle,
+                  style: AppTextStyles.titleMedium),
+            ),
+          ),
+          const Divider(height: 1, color: AppColors.borderGray),
+          rolesAsync.when(
+            loading: () => const Padding(
+              padding: EdgeInsets.all(32),
+              child: CircularProgressIndicator(),
+            ),
+            error: (e, _) => const SizedBox.shrink(),
+            data: (roles) => ListView.separated(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: roles.length,
+              separatorBuilder: (_, __) =>
+              const Divider(height: 1, color: AppColors.borderGray),
+              itemBuilder: (context, index) {
+                final role = roles[index];
+                final isSelected = role.id == employee.role.id;
+
+                return InkWell(
+                  onTap: () {
+                    ref
+                        .read(employeeListProvider.notifier)
+                        .updateEmployeeRole(employee.id, role);
+                    Navigator.pop(context);
+                  },
+                  child: Padding(
+                    padding: rs.pxy(horizontal: 24, vertical: 16),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: Text(role.name,
+                              style: AppTextStyles.body),
+                        ),
+                        if (isSelected)
+                          Icon(Icons.check,
+                              color: AppColors.darkBackground,
+                              size: rs.w(20)),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          SizedBox(height: rs.h(24)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -71,25 +71,35 @@ class HomeScreen extends StatelessWidget {
 
   Widget _buildMenuGrid(BuildContext context) {
     final rs = ResponsiveSize.of(context);
+    final s = S.of(context);
     final menuItems = [
       _MenuItem(
         icon: Icons.notifications_outlined,
-        label: S.of(context).noticesMenuLabel,
+        label: s.noticesMenuLabel,
         onTap: () => context.push(HomePath.notices),
+      ),
+      _MenuItem(
+        icon: Icons.manage_accounts_outlined,
+        label: s.roleManagementMenuLabel,
+        onTap: () => context.push(RolePath.root),
+      ),
+      _MenuItem(
+        icon: Icons.people_outline,
+        label: s.employeeAddMenuLabel,
+        onTap: () => context.push(EmployeePath.contractMethod),
       ),
     ];
 
-    return Row(
-      children: menuItems.map((item) {
-        return Expanded(
-          child: Padding(
-            padding: EdgeInsets.only(
-              right: item == menuItems.last ? 0 : rs.w(12),
-            ),
-            child: _buildMenuCard(context, item),
-          ),
-        );
-      }).toList(),
+    return GridView.count(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      crossAxisCount: 2,
+      crossAxisSpacing: rs.w(12),
+      mainAxisSpacing: rs.h(12),
+      childAspectRatio: 1.2,
+      children: menuItems
+          .map((item) => _buildMenuCard(context, item))
+          .toList(),
     );
   }
 
@@ -105,6 +115,7 @@ class HomeScreen extends StatelessWidget {
           borderRadius: rs.radius(16),
         ),
         child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Icon(item.icon, size: rs.w(32), color: AppColors.textPrimary),
             SizedBox(height: rs.h(12)),

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -84,9 +84,9 @@ class HomeScreen extends StatelessWidget {
         onTap: () => context.push(RolePath.root),
       ),
       _MenuItem(
-        icon: Icons.people_outline,
-        label: s.employeeAddMenuLabel,
-        onTap: () => context.push(EmployeePath.contractMethod),
+      icon: Icons.people_outline,
+      label: s.employeeManagementTitle,
+      onTap: () => context.push(EmployeePath.list),
       ),
     ];
 

--- a/lib/features/role/role_add_screen.dart
+++ b/lib/features/role/role_add_screen.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../core/theme/app_theme.dart';
+import '../../core/utils/responsive_size.dart';
+import '../../common/widgets/primary_button.dart';
+import '../../l10n/app_localizations.dart';
+import 'role_provider.dart';
+import 'widgets/role_card.dart';
+import 'widgets/permission_toggle_tile.dart';
+
+class _RoleAddState {
+  final int step;
+  final String? selectedTypeKey;
+  final String roleName;
+  final Set<String> enabledPermissions;
+
+  const _RoleAddState({
+    this.step = 0,
+    this.selectedTypeKey,
+    this.roleName = '',
+    this.enabledPermissions = const {},
+  });
+
+  _RoleAddState copyWith({
+    int? step,
+    String? selectedTypeKey,
+    String? roleName,
+    Set<String>? enabledPermissions,
+  }) =>
+      _RoleAddState(
+        step: step ?? this.step,
+        selectedTypeKey: selectedTypeKey ?? this.selectedTypeKey,
+        roleName: roleName ?? this.roleName,
+        enabledPermissions: enabledPermissions ?? this.enabledPermissions,
+      );
+}
+
+const _roleTypeKeys = ['manager', 'partTimer', 'employee', 'newRole'];
+
+const _roleTypeIcons = {
+  'manager':   Icons.manage_accounts_outlined,
+  'partTimer': Icons.access_time_outlined,
+  'employee':  Icons.person_outline,
+  'newRole':   Icons.add_circle_outline,
+};
+
+class RoleAddScreen extends ConsumerStatefulWidget {
+  const RoleAddScreen({super.key});
+
+  @override
+  ConsumerState<RoleAddScreen> createState() => _RoleAddScreenState();
+}
+
+class _RoleAddScreenState extends ConsumerState<RoleAddScreen> {
+  _RoleAddState _state = const _RoleAddState();
+  final _nameController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  String _roleTypeLabel(BuildContext context, String key) {
+    final s = S.of(context);
+    switch (key) {
+      case 'manager':   return s.roleTypeManager;
+      case 'partTimer': return s.roleTypePartTimer;
+      case 'employee':  return s.roleTypeEmployee;
+      case 'newRole':   return s.roleTypeNewRole;
+      default:          return key;
+    }
+  }
+
+  void _onTypeSelected(String key) {
+    // TODO : API 연결 후 수정
+    final preset = presetPermissionsFor(key);
+    setState(() {
+      _state = _state.copyWith(
+        selectedTypeKey: key,
+        enabledPermissions: Set.from(preset),
+      );
+    });
+  }
+
+  void _onPermissionToggled(String key, bool value) {
+    final updated = Set<String>.from(_state.enabledPermissions);
+    value ? updated.add(key) : updated.remove(key);
+    setState(() => _state = _state.copyWith(enabledPermissions: updated));
+  }
+
+  bool _canProceed() {
+    if (_state.step == 0) return _state.selectedTypeKey != null;
+    return _nameController.text.trim().isNotEmpty;
+  }
+
+  Future<void> _submit() async {
+    final success = await ref.read(roleMutationProvider.notifier).create(
+      name: _nameController.text.trim(),
+      description: _state.selectedTypeKey ?? '',
+      permissions: _state.enabledPermissions.toList(),
+    );
+    if (success && mounted) context.pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rs = ResponsiveSize.of(context);
+    final s = S.of(context);
+    final isMutating = ref.watch(roleMutationProvider).isLoading;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+            _state.step == 0 ? s.roleAddTitle : s.rolePermissionTitle),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {
+            if (_state.step == 1) {
+              setState(() => _state = _state.copyWith(step: 0));
+            } else {
+              context.pop();
+            }
+          },
+        ),
+      ),
+      body: _state.step == 0
+          ? _buildStep1(context, rs, s)
+          : _buildStep2(context, rs, s),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: rs.pxy(horizontal: 24, vertical: 16),
+          child: PrimaryButton(
+            text: _state.step == 0 ? s.roleNextButton : s.roleCompleteButton,
+            enabled: _canProceed() && !isMutating,
+            onPressed: _state.step == 0
+                ? () => setState(() => _state = _state.copyWith(step: 1))
+                : _submit,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStep1(BuildContext context, ResponsiveSize rs, S s) {
+    return Padding(
+      padding: rs.pxy(horizontal: 24, vertical: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(s.roleAddStepOneHeading, style: AppTextStyles.titleMedium),
+          SizedBox(height: rs.h(8)),
+          Text(s.roleAddStepOneSubtitle, style: AppTextStyles.caption),
+          SizedBox(height: rs.h(24)),
+          GridView.count(
+            shrinkWrap: true,
+            crossAxisCount: 2,
+            crossAxisSpacing: rs.w(12),
+            mainAxisSpacing: rs.h(12),
+            childAspectRatio: 1.4,
+            children: _roleTypeKeys.map((key) {
+              return RoleCard(
+                icon: _roleTypeIcons[key]!,
+                label: _roleTypeLabel(context, key),
+                isSelected: _state.selectedTypeKey == key,
+                onTap: () => _onTypeSelected(key),
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStep2(BuildContext context, ResponsiveSize rs, S s) {
+    final permissions = ref.watch(permissionListProvider);
+
+    return ListView(
+      children: [
+        Padding(
+          padding: rs.pxy(horizontal: 24, vertical: 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(s.roleNameLabel, style: AppTextStyles.label),
+              SizedBox(height: rs.h(8)),
+              TextField(
+                controller: _nameController,
+                onChanged: (_) => setState(() {}),
+                decoration: AppInputDecorations.outlined(
+                  hintText: s.roleNameHint,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1, color: AppColors.borderGray),
+        Padding(
+          padding: rs.pxy(horizontal: 24, vertical: 16),
+          child: Text(s.rolePermissionLabel, style: AppTextStyles.label),
+        ),
+        ...permissions.map((permission) => Column(
+          children: [
+            PermissionToggleTile(
+              permission: permission,
+              isEnabled: _state.enabledPermissions.contains(permission.key),
+              onChanged: (v) => _onPermissionToggled(permission.key, v),
+            ),
+            const Divider(height: 1, color: AppColors.borderGray),
+          ],
+        )),
+      ],
+    );
+  }
+}

--- a/lib/features/role/role_detail_screen.dart
+++ b/lib/features/role/role_detail_screen.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../core/theme/app_theme.dart';
+import '../../core/utils/responsive_size.dart';
+import '../../common/widgets/primary_button.dart';
+import '../../l10n/app_localizations.dart';
+import 'role_provider.dart';
+import 'widgets/permission_toggle_tile.dart';
+
+class RoleDetailScreen extends ConsumerStatefulWidget {
+  final RoleModel role;
+
+  const RoleDetailScreen({super.key, required this.role});
+
+  @override
+  ConsumerState<RoleDetailScreen> createState() => _RoleDetailScreenState();
+}
+
+class _RoleDetailScreenState extends ConsumerState<RoleDetailScreen> {
+  late Set<String> _enabledPermissions;
+  late TextEditingController _nameController;
+  bool _isEdited = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _enabledPermissions = Set.from(widget.role.permissions);
+    _nameController = TextEditingController(text: widget.role.name);
+    _nameController.addListener(_onChanged);
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _onChanged() {
+    final nameChanged = _nameController.text.trim() != widget.role.name;
+    final permChanged = !_setEquals(
+        _enabledPermissions, Set.from(widget.role.permissions));
+    setState(() => _isEdited = nameChanged || permChanged);
+  }
+
+  void _onPermissionToggled(String key, bool value) {
+    setState(() {
+      value ? _enabledPermissions.add(key) : _enabledPermissions.remove(key);
+    });
+    _onChanged();
+  }
+
+  bool _setEquals(Set<String> a, Set<String> b) =>
+      a.length == b.length && a.containsAll(b);
+
+  Future<void> _submit() async {
+    final success = await ref.read(roleMutationProvider.notifier).update(
+      roleId: widget.role.id,
+      name: _nameController.text.trim(),
+      description: widget.role.description,
+      permissions: _enabledPermissions.toList(),
+    );
+    if (success && mounted) context.pop();
+  }
+
+  void _showDeleteDialog(BuildContext context) {
+    final rs = ResponsiveSize.of(context);
+    final s = S.of(context);
+
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: rs.radius(16)),
+        title: Text(s.roleDeleteDialogTitle),
+        content: Text(
+          s.roleDeleteDialogMessage,
+          style: AppTextStyles.caption,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => ctx.pop(),
+            child: Text(s.cancelButton,
+                style: AppTextStyles.body
+                    .copyWith(color: AppColors.textSecondary)),
+          ),
+          TextButton(
+            onPressed: () {
+              ref.read(roleListProvider.notifier).deleteRole(widget.role.id);
+              ctx.pop();
+              context.pop();
+            },
+            child: Text(s.roleDeleteButton,
+                style: AppTextStyles.body.copyWith(color: AppColors.error)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final permissions = ref.watch(permissionListProvider);
+    final isMutating = ref.watch(roleMutationProvider).isLoading;
+    final rs = ResponsiveSize.of(context);
+    final s = S.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(s.roleDetailTitle),
+        actions: [
+          TextButton(
+            onPressed: () => _showDeleteDialog(context),
+            child: Text(s.roleDeleteButton,
+                style: AppTextStyles.body.copyWith(color: AppColors.error)),
+          ),
+        ],
+      ),
+      body: ListView(
+        children: [
+          Padding(
+            padding: rs.pxy(horizontal: 24, vertical: 24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(s.roleNameLabel, style: AppTextStyles.label),
+                SizedBox(height: rs.h(8)),
+                TextField(
+                  controller: _nameController,
+                  decoration: AppInputDecorations.outlined(),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1, color: AppColors.borderGray),
+          Padding(
+            padding: rs.pxy(horizontal: 24, vertical: 16),
+            child: Text(s.rolePermissionLabel, style: AppTextStyles.label),
+          ),
+          ...permissions.map((permission) => Column(
+            children: [
+              PermissionToggleTile(
+                permission: permission,
+                isEnabled: _enabledPermissions.contains(permission.key),
+                onChanged: (v) => _onPermissionToggled(permission.key, v),
+              ),
+              const Divider(height: 1, color: AppColors.borderGray),
+            ],
+          )),
+        ],
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: rs.pxy(horizontal: 24, vertical: 16),
+          child: PrimaryButton(
+            text: s.roleSaveButton,
+            enabled: _isEdited && !isMutating,
+            onPressed: _submit,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/role/role_list_screen.dart
+++ b/lib/features/role/role_list_screen.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../core/router/route_path.dart';
+import '../../core/theme/app_theme.dart';
+import '../../core/utils/responsive_size.dart';
+import '../../common/widgets/primary_button.dart';
+import '../../l10n/app_localizations.dart';
+import 'role_provider.dart';
+import 'widgets/role_list_tile.dart';
+
+class RoleListScreen extends ConsumerWidget {
+  const RoleListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final rolesAsync = ref.watch(roleListProvider);
+    final rs = ResponsiveSize.of(context);
+    final s = S.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(s.roleManagementTitle),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () => context.push(RolePath.add),
+          ),
+        ],
+      ),
+      body: rolesAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(s.networkError, style: AppTextStyles.body),
+              SizedBox(height: rs.h(12)),
+              TextButton(
+                onPressed: () =>
+                    ref.read(roleListProvider.notifier).fetch(refresh: true),
+                child: Text(s.retryButton),
+              ),
+            ],
+          ),
+        ),
+        data: (roles) => roles.isEmpty
+            ? _buildEmptyState(context, rs, s)
+            : _buildList(context, roles, rs),
+      ),
+    );
+  }
+
+  Widget _buildList(
+      BuildContext context, List<RoleModel> roles, ResponsiveSize rs) {
+    return ListView.separated(
+      itemCount: roles.length,
+      separatorBuilder: (_, __) =>
+      const Divider(height: 1, color: AppColors.borderGray),
+      itemBuilder: (context, index) {
+        final role = roles[index];
+        return RoleListTile(
+          role: role,
+          onTap: () => context.push(RolePath.detail, extra: role),
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context, ResponsiveSize rs, S s) {
+    return Center(
+      child: Padding(
+        padding: rs.px(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.manage_accounts_outlined,
+              size: rs.w(64),
+              color: AppColors.textSecondary,
+            ),
+            SizedBox(height: rs.h(16)),
+            Text(s.roleEmptyStateHeading, style: AppTextStyles.titleMedium),
+            SizedBox(height: rs.h(8)),
+            Text(
+              s.roleEmptyStateSubtitle,
+              style: AppTextStyles.caption,
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: rs.h(32)),
+            PrimaryButton(
+              text: s.roleEmptyStateButton,
+              onPressed: () => context.push(RolePath.add),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/role/role_model.dart
+++ b/lib/features/role/role_model.dart
@@ -1,0 +1,19 @@
+class RoleModel {
+  final String id;
+  final String name;
+  final String description;
+  final RoleType type;
+
+  const RoleModel({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.type,
+  });
+}
+
+enum RoleType {
+  manager,
+  partTimer,
+  employee,
+}

--- a/lib/features/role/role_provider.dart
+++ b/lib/features/role/role_provider.dart
@@ -1,0 +1,188 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class RoleModel {
+  const RoleModel({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.permissions,
+  });
+
+  final int id;
+  final String name;
+  final String description;
+  final List<String> permissions;
+
+  factory RoleModel.fromJson(Map<String, dynamic> json) => RoleModel(
+    id: json['id'] as int,
+    name: json['name'] as String,
+    description: json['description'] as String? ?? '',
+    permissions: (json['permissions'] as List? ?? [])
+        .map((e) => e as String)
+        .toList(),
+  );
+}
+
+class PermissionModel {
+  const PermissionModel({required this.key});
+  final String key;
+}
+
+// 권한 키 상수
+
+abstract class PermissionKey {
+  static const staffManage    = 'staff_manage';
+  static const storeManage    = 'store_manage';
+  static const contractManage = 'contract_manage';
+  static const salaryManage   = 'salary_manage';
+  static const staffInvite    = 'staff_invite';
+}
+
+//  Mock 데이터
+
+const _mockPermissions = [
+  PermissionModel(key: PermissionKey.staffManage),
+  PermissionModel(key: PermissionKey.storeManage),
+  PermissionModel(key: PermissionKey.contractManage),
+  PermissionModel(key: PermissionKey.salaryManage),
+  PermissionModel(key: PermissionKey.staffInvite),
+];
+
+// 역할 유형별 기본 권한 프리셋
+const _presetPermissions = {
+  'manager': [
+    PermissionKey.staffManage,
+    PermissionKey.storeManage,
+    PermissionKey.contractManage,
+    PermissionKey.salaryManage,
+    PermissionKey.staffInvite,
+  ],
+  'partTimer': [
+    PermissionKey.storeManage,
+  ],
+  'employee': [
+    PermissionKey.storeManage,
+    PermissionKey.contractManage,
+  ],
+  'newRole': <String>[],
+};
+
+List<String> presetPermissionsFor(String typeKey) =>
+    List.from(_presetPermissions[typeKey] ?? []);
+
+final _mockRoles = [
+  RoleModel(
+    id: 1,
+    name: '매니저',
+    description: 'manager',
+    permissions: _presetPermissions['manager']!,
+  ),
+  RoleModel(
+    id: 2,
+    name: '파트타이머',
+    description: 'partTimer',
+    permissions: _presetPermissions['partTimer']!,
+  ),
+];
+
+// 역할 목록 Provider
+// TODO: API 연동 시 수정
+
+final roleListProvider =
+StateNotifierProvider<RoleListNotifier, AsyncValue<List<RoleModel>>>(
+        (ref) => RoleListNotifier());
+
+class RoleListNotifier extends StateNotifier<AsyncValue<List<RoleModel>>> {
+  RoleListNotifier() : super(const AsyncLoading()) {
+    fetch();
+  }
+
+  Future<void> fetch({bool refresh = false}) async {
+    state = const AsyncLoading();
+    await Future.delayed(const Duration(milliseconds: 300));
+    state = AsyncData(List.from(_mockRoles));
+  }
+
+  void addRole(RoleModel role) {
+    final current = state.valueOrNull ?? [];
+    state = AsyncData([...current, role]);
+  }
+
+  void updateRole(RoleModel updated) {
+    final current = state.valueOrNull ?? [];
+    state = AsyncData(
+        current.map((r) => r.id == updated.id ? updated : r).toList());
+  }
+
+  void deleteRole(int id) {
+    final current = state.valueOrNull ?? [];
+
+    state = AsyncData(current.where((r) => r.id != id).toList());
+  }
+}
+
+//권한 목록 Provider
+
+final permissionListProvider =
+Provider<List<PermissionModel>>((ref) => _mockPermissions);
+
+// 역할 생성/수정 Provider
+
+final roleMutationProvider =
+StateNotifierProvider<RoleMutationNotifier, AsyncValue<void>>(
+        (ref) => RoleMutationNotifier(ref));
+
+class RoleMutationNotifier extends StateNotifier<AsyncValue<void>> {
+  RoleMutationNotifier(this._ref) : super(const AsyncData(null));
+
+  final Ref _ref;
+
+  Future<bool> create({
+    required String name,
+    required String description,
+    required List<String> permissions,
+  }) async {
+    state = const AsyncLoading();
+    try {
+      await Future.delayed(const Duration(milliseconds: 300));
+      // TODO: API 연동 시 Mock 코드 제거 후 교체
+      final newRole = RoleModel(
+        id: DateTime.now().millisecondsSinceEpoch,
+        name: name,
+        description: description,
+        permissions: permissions,
+      );
+      _ref.read(roleListProvider.notifier).addRole(newRole);
+      state = const AsyncData(null);
+      return true;
+    } catch (e) {
+      state = AsyncError(e, StackTrace.current);
+      return false;
+    }
+  }
+
+  Future<bool> update({
+    required int roleId,
+    required String name,
+    required String description,
+    required List<String> permissions,
+  }) async {
+    state = const AsyncLoading();
+    try {
+      await Future.delayed(const Duration(milliseconds: 300));
+      // TODO: API 연동 시 Mock 코드 제거 후 교체
+      final updated = RoleModel(
+        id: roleId,
+        name: name,
+        description: description,
+        permissions: permissions,
+      );
+      _ref.read(roleListProvider.notifier).updateRole(updated);
+      state = const AsyncData(null);
+      return true;
+    } catch (e) {
+      state = AsyncError(e, StackTrace.current);
+      return false;
+    }
+  }
+}

--- a/lib/features/role/widgets/permission_toggle_tile.dart
+++ b/lib/features/role/widgets/permission_toggle_tile.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/responsive_size.dart';
+import '../../../l10n/app_localizations.dart';
+import '../role_provider.dart';
+
+class PermissionToggleTile extends StatelessWidget {
+  final PermissionModel permission;
+  final bool isEnabled;
+  final ValueChanged<bool> onChanged;
+
+  const PermissionToggleTile({
+    super.key,
+    required this.permission,
+    required this.isEnabled,
+    required this.onChanged,
+  });
+
+  String _label(BuildContext context) {
+    final s = S.of(context);
+    switch (permission.key) {
+      case PermissionKey.staffManage:    return s.permissionStaffManage;
+      case PermissionKey.storeManage:    return s.permissionStoreManage;
+      case PermissionKey.contractManage: return s.permissionContractManage;
+      case PermissionKey.salaryManage:   return s.permissionSalaryManage;
+      case PermissionKey.staffInvite:    return s.permissionStaffInvite;
+      default:                           return permission.key;
+    }
+  }
+
+  String _desc(BuildContext context) {
+    final s = S.of(context);
+    switch (permission.key) {
+      case PermissionKey.staffManage:    return s.permissionStaffManageDesc;
+      case PermissionKey.storeManage:    return s.permissionStoreManageDesc;
+      case PermissionKey.contractManage: return s.permissionContractManageDesc;
+      case PermissionKey.salaryManage:   return s.permissionSalaryManageDesc;
+      case PermissionKey.staffInvite:    return s.permissionStaffInviteDesc;
+      default:                           return '';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rs = ResponsiveSize.of(context);
+
+    return Padding(
+      padding: rs.pxy(horizontal: 24, vertical: 14),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(_label(context), style: AppTextStyles.body),
+                SizedBox(height: rs.h(2)),
+                Text(
+                  _desc(context),
+                  style: AppTextStyles.caption,
+                ),
+              ],
+            ),
+          ),
+          Switch(
+            value: isEnabled,
+            onChanged: onChanged,
+            activeColor: AppColors.darkBackground,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/role/widgets/role_card.dart
+++ b/lib/features/role/widgets/role_card.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/responsive_size.dart';
+
+class RoleCard extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const RoleCard({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final rs = ResponsiveSize.of(context);
+
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        padding: rs.pxy(horizontal: 12, vertical: 16),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? AppColors.darkBackground.withOpacity(0.08)
+              : AppColors.lightGray,
+          borderRadius: rs.radius(12),
+          border: Border.all(
+            color: isSelected ? AppColors.darkBackground : Colors.transparent,
+            width: 1.5,
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              icon,
+              size: rs.w(32),
+              color: isSelected
+                  ? AppColors.darkBackground
+                  : AppColors.textSecondary,
+            ),
+            SizedBox(height: rs.h(8)),
+            Text(
+              label,
+              style: AppTextStyles.label.copyWith(
+                color: isSelected
+                    ? AppColors.darkBackground
+                    : AppColors.textPrimary,
+                fontWeight:
+                isSelected ? FontWeight.w600 : FontWeight.w400,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/role/widgets/role_list_tile.dart
+++ b/lib/features/role/widgets/role_list_tile.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/responsive_size.dart';
+import '../../../l10n/app_localizations.dart';
+import '../role_provider.dart';
+
+class RoleListTile extends StatelessWidget {
+  final RoleModel role;
+  final VoidCallback onTap;
+
+  const RoleListTile({
+    super.key,
+    required this.role,
+    required this.onTap,
+  });
+
+  String _permissionLabel(BuildContext context, String key) {
+    final s = S.of(context);
+    switch (key) {
+      case PermissionKey.staffManage:    return s.permissionStaffManage;
+      case PermissionKey.storeManage:    return s.permissionStoreManage;
+      case PermissionKey.contractManage: return s.permissionContractManage;
+      case PermissionKey.salaryManage:   return s.permissionSalaryManage;
+      case PermissionKey.staffInvite:    return s.permissionStaffInvite;
+      default:                           return key;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rs = ResponsiveSize.of(context);
+    final permissions = role.permissions;
+
+    // 최대 3개까지 표시, 초과시 +N개 표시
+    const maxVisible = 3;
+    final visible = permissions.take(maxVisible).toList();
+    final overflow = permissions.length - maxVisible;
+
+    final permissionText = [
+      ...visible.map((k) => _permissionLabel(context, k)),
+      if (overflow > 0) '+$overflow개',
+    ].join(' · ');
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: rs.pxy(horizontal: 24, vertical: 16),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(role.name, style: AppTextStyles.titleMedium),
+                  SizedBox(height: rs.h(4)),
+                  Text(
+                    permissions.isEmpty ? '-' : permissionText,
+                    style: AppTextStyles.caption,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            Icon(
+              Icons.chevron_right,
+              color: AppColors.textSecondary,
+              size: rs.w(24),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -99,554 +99,902 @@ abstract class S {
 
   /// No description provided for @kakaoLoginButton.
   ///
-  /// In ko, this message translates to:
-  /// **'카카오 로그인'**
+  /// In en, this message translates to:
+  /// **'Kakao Login'**
   String get kakaoLoginButton;
 
   /// No description provided for @startWithKakao.
   ///
-  /// In ko, this message translates to:
-  /// **'카카오계정으로 시작하기'**
+  /// In en, this message translates to:
+  /// **'Start with Kakao account'**
   String get startWithKakao;
 
   /// No description provided for @loginFailError.
   ///
-  /// In ko, this message translates to:
-  /// **'로그인에 실패했습니다. 다시 시도해 주세요.'**
+  /// In en, this message translates to:
+  /// **'Login failed. Please try again.'**
   String get loginFailError;
 
   /// No description provided for @phoneVerificationTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'휴대폰 인증'**
+  /// In en, this message translates to:
+  /// **'Phone Verification'**
   String get phoneVerificationTitle;
 
   /// No description provided for @phoneVerificationSubtitle.
   ///
-  /// In ko, this message translates to:
-  /// **'안전한 서비스 이용을 위해 본인 인증을 진행합니다'**
+  /// In en, this message translates to:
+  /// **'Please verify your identity for safe service use'**
   String get phoneVerificationSubtitle;
 
   /// No description provided for @phoneNumberLabel.
   ///
-  /// In ko, this message translates to:
-  /// **'휴대폰 번호'**
+  /// In en, this message translates to:
+  /// **'Phone number'**
   String get phoneNumberLabel;
 
   /// No description provided for @phoneNumberHint.
   ///
-  /// In ko, this message translates to:
+  /// In en, this message translates to:
   /// **'01012345678'**
   String get phoneNumberHint;
 
   /// No description provided for @getAuthCodeButton.
   ///
-  /// In ko, this message translates to:
-  /// **'인증번호 받기'**
+  /// In en, this message translates to:
+  /// **'Get verification code'**
   String get getAuthCodeButton;
 
   /// No description provided for @verifyAuthCodeTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'인증번호 확인'**
+  /// In en, this message translates to:
+  /// **'Verify Code'**
   String get verifyAuthCodeTitle;
 
   /// No description provided for @verifyAuthCodeSubtitle.
   ///
-  /// In ko, this message translates to:
-  /// **'휴대폰으로 전송된 6자리 번호를 입력해주세요'**
+  /// In en, this message translates to:
+  /// **'Enter the 6-digit code sent to your phone'**
   String get verifyAuthCodeSubtitle;
 
   /// No description provided for @invalidAuthCodeError.
   ///
-  /// In ko, this message translates to:
-  /// **'인증번호가 올바르지 않습니다. 다시 확인해주세요'**
+  /// In en, this message translates to:
+  /// **'Invalid verification code. Please try again.'**
   String get invalidAuthCodeError;
 
   /// No description provided for @resendAuthCodeButton.
   ///
-  /// In ko, this message translates to:
-  /// **'인증번호 재발송'**
+  /// In en, this message translates to:
+  /// **'Resend code'**
   String get resendAuthCodeButton;
 
   /// No description provided for @privacyConsentTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'개인정보 수집 및 이용 동의'**
+  /// In en, this message translates to:
+  /// **'Privacy Collection & Use Agreement'**
   String get privacyConsentTitle;
 
   /// No description provided for @privacySection1Title.
   ///
-  /// In ko, this message translates to:
-  /// **'1. 수집하는 개인정보 항목'**
+  /// In en, this message translates to:
+  /// **'1. Personal Information Collected'**
   String get privacySection1Title;
 
   /// No description provided for @privacySection1Content.
   ///
-  /// In ko, this message translates to:
-  /// **'회사는 서비스 제공을 위해 다음과 같은 개인정보를 수집하고 있습니다.'**
+  /// In en, this message translates to:
+  /// **'The company collects the following personal information for service provision.'**
   String get privacySection1Content;
 
   /// No description provided for @privacyRequiredItems.
   ///
-  /// In ko, this message translates to:
-  /// **'필수항목: 이름, 휴대전화번호'**
+  /// In en, this message translates to:
+  /// **'Required: Name, Phone number'**
   String get privacyRequiredItems;
 
   /// No description provided for @privacyOptionalItems.
   ///
-  /// In ko, this message translates to:
-  /// **'선택항목: 이메일 주소, 프로필 사진'**
+  /// In en, this message translates to:
+  /// **'Optional: Email address, Profile photo'**
   String get privacyOptionalItems;
 
   /// No description provided for @privacyAutoCollectedItems.
   ///
-  /// In ko, this message translates to:
-  /// **'자동 수집 항목: 접속 로그, 쿠키, 접속 IP 정보'**
+  /// In en, this message translates to:
+  /// **'Auto-collected: Access logs, Cookies, IP address'**
   String get privacyAutoCollectedItems;
 
   /// No description provided for @privacySection2Title.
   ///
-  /// In ko, this message translates to:
-  /// **'2. 개인정보의 수집 및 이용목적'**
+  /// In en, this message translates to:
+  /// **'2. Purpose of Collection & Use'**
   String get privacySection2Title;
 
   /// No description provided for @privacySection2Content.
   ///
-  /// In ko, this message translates to:
-  /// **'수집한 개인정보는 다음의 목적을 위해 활용됩니다.'**
+  /// In en, this message translates to:
+  /// **'Collected personal information is used for the following purposes.'**
   String get privacySection2Content;
 
   /// No description provided for @privacyUseMemberManagement.
   ///
-  /// In ko, this message translates to:
-  /// **'회원 가입 및 관리'**
+  /// In en, this message translates to:
+  /// **'Member registration and management'**
   String get privacyUseMemberManagement;
 
   /// No description provided for @privacyUseServiceProvision.
   ///
-  /// In ko, this message translates to:
-  /// **'서비스 제공 및 계약 이행'**
+  /// In en, this message translates to:
+  /// **'Service provision and contract fulfillment'**
   String get privacyUseServiceProvision;
 
   /// No description provided for @privacyUseAttendanceSalary.
   ///
-  /// In ko, this message translates to:
-  /// **'근태 관리 및 급여 지급'**
+  /// In en, this message translates to:
+  /// **'Attendance management and salary payment'**
   String get privacyUseAttendanceSalary;
 
   /// No description provided for @privacyUseNoticeDelivery.
   ///
-  /// In ko, this message translates to:
-  /// **'고지사항 전달 및 공지사항 발송'**
+  /// In en, this message translates to:
+  /// **'Notice delivery and announcement distribution'**
   String get privacyUseNoticeDelivery;
 
   /// No description provided for @privacyUseIdentityVerification.
   ///
-  /// In ko, this message translates to:
-  /// **'본인 확인 및 인증'**
+  /// In en, this message translates to:
+  /// **'Identity verification and authentication'**
   String get privacyUseIdentityVerification;
 
   /// No description provided for @privacySection3Title.
   ///
-  /// In ko, this message translates to:
-  /// **'3. 개인정보의 보유 및 이용기간'**
+  /// In en, this message translates to:
+  /// **'3. Retention Period'**
   String get privacySection3Title;
 
   /// No description provided for @privacySection3Content.
   ///
-  /// In ko, this message translates to:
-  /// **'회사는 법령에 따른 개인정보 보유·이용기간 또는 정보주체로부터 개인정보를 수집 시에 동의 받은 개인정보 보유·이용기간 내에서 개인정보를 처리·보유합니다.'**
+  /// In en, this message translates to:
+  /// **'The company processes and retains personal information within the retention period prescribed by law or agreed upon at the time of collection.'**
   String get privacySection3Content;
 
   /// No description provided for @privacyRetentionWithdrawal.
   ///
-  /// In ko, this message translates to:
-  /// **'회원 탈퇴 시: 즉시 삭제'**
+  /// In en, this message translates to:
+  /// **'Upon withdrawal: Immediately deleted'**
   String get privacyRetentionWithdrawal;
 
   /// No description provided for @privacyRetentionLegal.
   ///
-  /// In ko, this message translates to:
-  /// **'법령에 따른 보관: 관련 법령에서 정한 기간'**
+  /// In en, this message translates to:
+  /// **'Legal retention: As prescribed by applicable laws'**
   String get privacyRetentionLegal;
 
   /// No description provided for @salaryConsentTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'급여 정보 수집 동의'**
+  /// In en, this message translates to:
+  /// **'Salary Information Collection Agreement'**
   String get salaryConsentTitle;
 
   /// No description provided for @salarySection1Title.
   ///
-  /// In ko, this message translates to:
-  /// **'1. 수집하는 급여 정보'**
+  /// In en, this message translates to:
+  /// **'1. Salary Information Collected'**
   String get salarySection1Title;
 
   /// No description provided for @salarySection1Content.
   ///
-  /// In ko, this message translates to:
-  /// **'회사는 정확한 급여 지급 및 관리를 위해 다음과 같은 정보를 수집합니다.'**
+  /// In en, this message translates to:
+  /// **'The company collects the following information for accurate salary payment and management.'**
   String get salarySection1Content;
 
   /// No description provided for @salaryBasePay.
   ///
-  /// In ko, this message translates to:
-  /// **'기본급 및 수당 정보'**
+  /// In en, this message translates to:
+  /// **'Base pay and allowance information'**
   String get salaryBasePay;
 
   /// No description provided for @salaryWorkHours.
   ///
-  /// In ko, this message translates to:
-  /// **'근무 시간 및 근태 정보'**
+  /// In en, this message translates to:
+  /// **'Work hours and attendance information'**
   String get salaryWorkHours;
 
   /// No description provided for @salaryOvertimeHours.
   ///
-  /// In ko, this message translates to:
-  /// **'연장근무, 야간근무, 휴일근무 시간'**
+  /// In en, this message translates to:
+  /// **'Overtime, night shift, and holiday work hours'**
   String get salaryOvertimeHours;
 
   /// No description provided for @salaryBankAccount.
   ///
-  /// In ko, this message translates to:
-  /// **'급여 지급 계좌 정보'**
+  /// In en, this message translates to:
+  /// **'Salary payment account information'**
   String get salaryBankAccount;
 
   /// No description provided for @salaryTaxInsurance.
   ///
-  /// In ko, this message translates to:
-  /// **'소득세 및 4대 보험 관련 정보'**
+  /// In en, this message translates to:
+  /// **'Income tax and social insurance information'**
   String get salaryTaxInsurance;
 
   /// No description provided for @salaryLeaveHistory.
   ///
-  /// In ko, this message translates to:
-  /// **'연차 사용 내역'**
+  /// In en, this message translates to:
+  /// **'Annual leave usage history'**
   String get salaryLeaveHistory;
 
   /// No description provided for @salarySection2Title.
   ///
-  /// In ko, this message translates to:
-  /// **'2. 급여 정보의 이용 목적'**
+  /// In en, this message translates to:
+  /// **'2. Purpose of Use'**
   String get salarySection2Title;
 
   /// No description provided for @salarySection2Content.
   ///
-  /// In ko, this message translates to:
-  /// **'수집한 급여 정보는 다음의 목적으로 이용됩니다.'**
+  /// In en, this message translates to:
+  /// **'Collected salary information is used for the following purposes.'**
   String get salarySection2Content;
 
   /// No description provided for @salaryUseCalculation.
   ///
-  /// In ko, this message translates to:
-  /// **'정확한 급여 계산 및 지급'**
+  /// In en, this message translates to:
+  /// **'Accurate salary calculation and payment'**
   String get salaryUseCalculation;
 
   /// No description provided for @salaryUsePayslip.
   ///
-  /// In ko, this message translates to:
-  /// **'급여 명세서 작성 및 제공'**
+  /// In en, this message translates to:
+  /// **'Payslip creation and provision'**
   String get salaryUsePayslip;
 
   /// No description provided for @salaryUseInsurance.
   ///
-  /// In ko, this message translates to:
-  /// **'4대 보험 신고 및 관리'**
+  /// In en, this message translates to:
+  /// **'Social insurance reporting and management'**
   String get salaryUseInsurance;
 
   /// No description provided for @salaryUseTax.
   ///
-  /// In ko, this message translates to:
-  /// **'소득세 원천징수 및 연말정산'**
+  /// In en, this message translates to:
+  /// **'Income tax withholding and year-end settlement'**
   String get salaryUseTax;
 
   /// No description provided for @salaryUseLegalRecord.
   ///
-  /// In ko, this message translates to:
-  /// **'근로기준법에 따른 법정 기록 유지'**
+  /// In en, this message translates to:
+  /// **'Legal record keeping under labor law'**
   String get salaryUseLegalRecord;
 
   /// No description provided for @salaryUseDispute.
   ///
-  /// In ko, this message translates to:
-  /// **'급여 관련 분쟁 및 분쟁 해결'**
+  /// In en, this message translates to:
+  /// **'Salary-related dispute resolution'**
   String get salaryUseDispute;
 
   /// No description provided for @salarySection3Title.
   ///
-  /// In ko, this message translates to:
-  /// **'3. 급여 정보의 보유 및 이용 기간'**
+  /// In en, this message translates to:
+  /// **'3. Retention Period'**
   String get salarySection3Title;
 
   /// No description provided for @salarySection3Content.
   ///
-  /// In ko, this message translates to:
-  /// **'급여 관련 정보는 관련 법령에 따라 다음과 같이 보관됩니다.'**
+  /// In en, this message translates to:
+  /// **'Salary information is retained in accordance with applicable laws.'**
   String get salarySection3Content;
 
   /// No description provided for @enterAccountInfoTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'계좌 정보를 입력해 주세요'**
+  /// In en, this message translates to:
+  /// **'Enter account information'**
   String get enterAccountInfoTitle;
 
   /// No description provided for @registerAccountSubtitle.
   ///
-  /// In ko, this message translates to:
-  /// **'급여 수령에 사용될 계좌를 등록해 주세요'**
+  /// In en, this message translates to:
+  /// **'Register the account for salary payment'**
   String get registerAccountSubtitle;
 
   /// No description provided for @bankLabel.
   ///
-  /// In ko, this message translates to:
-  /// **'은행'**
+  /// In en, this message translates to:
+  /// **'Bank'**
   String get bankLabel;
 
   /// No description provided for @selectBankHint.
   ///
-  /// In ko, this message translates to:
-  /// **'은행을 선택하세요'**
+  /// In en, this message translates to:
+  /// **'Select a bank'**
   String get selectBankHint;
 
   /// No description provided for @accountNumberLabel.
   ///
-  /// In ko, this message translates to:
-  /// **'계좌번호'**
+  /// In en, this message translates to:
+  /// **'Account number'**
   String get accountNumberLabel;
 
   /// No description provided for @accountNumberHint.
   ///
-  /// In ko, this message translates to:
-  /// **'\'-\' 없이 숫자만 입력'**
+  /// In en, this message translates to:
+  /// **'Numbers only, no dashes'**
   String get accountNumberHint;
 
   /// No description provided for @accountAliasLabel.
   ///
-  /// In ko, this message translates to:
-  /// **'계좌 별칭'**
+  /// In en, this message translates to:
+  /// **'Account Alias'**
   String get accountAliasLabel;
 
   /// No description provided for @accountAliasHint.
   ///
-  /// In ko, this message translates to:
-  /// **'예) 급여계좌, 생활비계좌'**
+  /// In en, this message translates to:
+  /// **'e.g. Salary account, Living expenses'**
   String get accountAliasHint;
 
   /// No description provided for @noticeLabel.
   ///
-  /// In ko, this message translates to:
-  /// **'안내사항'**
+  /// In en, this message translates to:
+  /// **'Notice'**
   String get noticeLabel;
 
   /// No description provided for @accountRegistrationNotice.
   ///
-  /// In ko, this message translates to:
-  /// **'입력하신 계좌는 급여 수령 계좌로만 사용되며, 본인 명의의 계좌만 등록 가능합니다.'**
+  /// In en, this message translates to:
+  /// **'The account will be used only for salary payment. Only accounts in your name can be registered.'**
   String get accountRegistrationNotice;
 
   /// No description provided for @registerButton.
   ///
-  /// In ko, this message translates to:
-  /// **'등록하기'**
+  /// In en, this message translates to:
+  /// **'Register'**
   String get registerButton;
 
   /// No description provided for @noRegisteredAccounts.
   ///
-  /// In ko, this message translates to:
-  /// **'등록된 계좌가 없습니다.'**
+  /// In en, this message translates to:
+  /// **'No registered accounts.'**
   String get noRegisteredAccounts;
 
   /// No description provided for @addAccountButton.
   ///
-  /// In ko, this message translates to:
-  /// **'+ 계좌 추가'**
+  /// In en, this message translates to:
+  /// **'+ Add account'**
   String get addAccountButton;
 
   /// No description provided for @deleteAccountTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'계좌 삭제'**
+  /// In en, this message translates to:
+  /// **'Delete Account'**
   String get deleteAccountTitle;
 
   /// No description provided for @deleteAccountConfirmation.
   ///
-  /// In ko, this message translates to:
-  /// **'해당 계좌를 삭제하시겠습니까?'**
+  /// In en, this message translates to:
+  /// **'Are you sure you want to delete this account?'**
   String get deleteAccountConfirmation;
 
   /// No description provided for @deleteButton.
   ///
-  /// In ko, this message translates to:
-  /// **'삭제'**
+  /// In en, this message translates to:
+  /// **'Delete'**
   String get deleteButton;
 
   /// No description provided for @changeButton.
   ///
-  /// In ko, this message translates to:
-  /// **'변경'**
+  /// In en, this message translates to:
+  /// **'Change'**
   String get changeButton;
 
   /// No description provided for @accountHolderLabel.
   ///
-  /// In ko, this message translates to:
-  /// **'예금주'**
+  /// In en, this message translates to:
+  /// **'Account holder'**
   String get accountHolderLabel;
 
   /// No description provided for @accountInfoHeaderTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'계좌 정보'**
+  /// In en, this message translates to:
+  /// **'Account Info'**
   String get accountInfoHeaderTitle;
 
   /// No description provided for @accountInfoMenuLabel.
   ///
-  /// In ko, this message translates to:
-  /// **'계좌 정보'**
+  /// In en, this message translates to:
+  /// **'Account Info'**
   String get accountInfoMenuLabel;
 
   /// No description provided for @homeBannerTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'새로운 교육 시스템'**
+  /// In en, this message translates to:
+  /// **'New Education System'**
   String get homeBannerTitle;
 
   /// No description provided for @homeBannerSubtitle.
   ///
-  /// In ko, this message translates to:
-  /// **'직원 교육을 더 쉽게 관리하세요'**
+  /// In en, this message translates to:
+  /// **'Manage employee training more easily'**
   String get homeBannerSubtitle;
 
   /// No description provided for @noticesMenuLabel.
   ///
-  /// In ko, this message translates to:
-  /// **'공지사항'**
+  /// In en, this message translates to:
+  /// **'Notices'**
   String get noticesMenuLabel;
 
   /// No description provided for @noticesHeaderTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'공지사항'**
+  /// In en, this message translates to:
+  /// **'Notices'**
   String get noticesHeaderTitle;
 
   /// No description provided for @myPageHeaderTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'마이페이지'**
+  /// In en, this message translates to:
+  /// **'My Page'**
   String get myPageHeaderTitle;
 
   /// No description provided for @viewProfileLink.
   ///
-  /// In ko, this message translates to:
-  /// **'프로필 보기'**
+  /// In en, this message translates to:
+  /// **'View profile'**
   String get viewProfileLink;
 
   /// No description provided for @noNotices.
   ///
-  /// In ko, this message translates to:
-  /// **'등록된 공지사항이 없습니다.'**
+  /// In en, this message translates to:
+  /// **'No notices available.'**
   String get noNotices;
+
+  /// No description provided for @roleManagementMenuLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Role Management'**
+  String get roleManagementMenuLabel;
+
+  /// No description provided for @employeeAddMenuLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Employee'**
+  String get employeeAddMenuLabel;
+
+  /// No description provided for @roleManagementTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Role Management'**
+  String get roleManagementTitle;
+
+  /// No description provided for @roleAddTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Role'**
+  String get roleAddTitle;
+
+  /// No description provided for @rolePermissionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Permission Settings'**
+  String get rolePermissionTitle;
+
+  /// No description provided for @roleDetailTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Role Detail'**
+  String get roleDetailTitle;
+
+  /// No description provided for @roleEmptyStateHeading.
+  ///
+  /// In en, this message translates to:
+  /// **'Create your first role'**
+  String get roleEmptyStateHeading;
+
+  /// No description provided for @roleEmptyStateSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Set up roles before inviting employees\nto manage permissions easily.'**
+  String get roleEmptyStateSubtitle;
+
+  /// No description provided for @roleEmptyStateButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Get Started'**
+  String get roleEmptyStateButton;
+
+  /// No description provided for @roleAddStepOneHeading.
+  ///
+  /// In en, this message translates to:
+  /// **'What kind of role?'**
+  String get roleAddStepOneHeading;
+
+  /// No description provided for @roleAddStepOneSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Default permissions will be set based on the role type.'**
+  String get roleAddStepOneSubtitle;
+
+  /// No description provided for @roleTypeManager.
+  ///
+  /// In en, this message translates to:
+  /// **'Manager'**
+  String get roleTypeManager;
+
+  /// No description provided for @roleTypePartTimer.
+  ///
+  /// In en, this message translates to:
+  /// **'Part-timer'**
+  String get roleTypePartTimer;
+
+  /// No description provided for @roleTypeEmployee.
+  ///
+  /// In en, this message translates to:
+  /// **'Employee'**
+  String get roleTypeEmployee;
+
+  /// No description provided for @roleTypeNewRole.
+  ///
+  /// In en, this message translates to:
+  /// **'Create New Role'**
+  String get roleTypeNewRole;
+
+  /// No description provided for @roleNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Role Name'**
+  String get roleNameLabel;
+
+  /// No description provided for @roleNameHint.
+  ///
+  /// In en, this message translates to:
+  /// **'e.g. Weekend Manager'**
+  String get roleNameHint;
+
+  /// No description provided for @rolePermissionLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Permissions'**
+  String get rolePermissionLabel;
+
+  /// No description provided for @roleNextButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Next'**
+  String get roleNextButton;
+
+  /// No description provided for @roleSaveButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get roleSaveButton;
+
+  /// No description provided for @roleCompleteButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Done'**
+  String get roleCompleteButton;
+
+  /// No description provided for @roleDeleteButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get roleDeleteButton;
+
+  /// No description provided for @roleDeleteDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete this role?'**
+  String get roleDeleteDialogTitle;
+
+  /// No description provided for @roleDeleteDialogMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Employees assigned to this role\nmay have their role removed.'**
+  String get roleDeleteDialogMessage;
+
+  /// No description provided for @permissionStaffManage.
+  ///
+  /// In en, this message translates to:
+  /// **'Staff Management'**
+  String get permissionStaffManage;
+
+  /// No description provided for @permissionStaffManageDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Register and manage employees'**
+  String get permissionStaffManageDesc;
+
+  /// No description provided for @permissionStoreManage.
+  ///
+  /// In en, this message translates to:
+  /// **'Store Management'**
+  String get permissionStoreManage;
+
+  /// No description provided for @permissionStoreManageDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'View and edit store information'**
+  String get permissionStoreManageDesc;
+
+  /// No description provided for @permissionContractManage.
+  ///
+  /// In en, this message translates to:
+  /// **'Contract Management'**
+  String get permissionContractManage;
+
+  /// No description provided for @permissionContractManageDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Register and review contracts'**
+  String get permissionContractManageDesc;
+
+  /// No description provided for @permissionSalaryManage.
+  ///
+  /// In en, this message translates to:
+  /// **'Payroll'**
+  String get permissionSalaryManage;
+
+  /// No description provided for @permissionSalaryManageDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'View and manage payroll'**
+  String get permissionSalaryManageDesc;
+
+  /// No description provided for @permissionStaffInvite.
+  ///
+  /// In en, this message translates to:
+  /// **'Invite Staff'**
+  String get permissionStaffInvite;
+
+  /// No description provided for @permissionStaffInviteDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Generate and share invite codes'**
+  String get permissionStaffInviteDesc;
+
+  /// No description provided for @contractMethodTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Employment Contract'**
+  String get contractMethodTitle;
+
+  /// No description provided for @contractMethodHeading.
+  ///
+  /// In en, this message translates to:
+  /// **'How would you like to register?'**
+  String get contractMethodHeading;
+
+  /// No description provided for @contractMethodDirectLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Upload PDF'**
+  String get contractMethodDirectLabel;
+
+  /// No description provided for @contractMethodDirectDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Upload a PDF file directly'**
+  String get contractMethodDirectDesc;
+
+  /// No description provided for @contractMethodTemplateLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Load Template'**
+  String get contractMethodTemplateLabel;
+
+  /// No description provided for @contractMethodTemplateDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'Coming soon'**
+  String get contractMethodTemplateDesc;
+
+  /// No description provided for @contractUploadTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Employment Contract'**
+  String get contractUploadTitle;
+
+  /// No description provided for @contractUploadHeading.
+  ///
+  /// In en, this message translates to:
+  /// **'Please upload the contract'**
+  String get contractUploadHeading;
+
+  /// No description provided for @contractUploadSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Only PDF files are supported'**
+  String get contractUploadSubtitle;
+
+  /// No description provided for @contractUploadButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Select File'**
+  String get contractUploadButton;
+
+  /// No description provided for @contractUploadNextButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Next'**
+  String get contractUploadNextButton;
+
+  /// No description provided for @contractUploadEmptyError.
+  ///
+  /// In en, this message translates to:
+  /// **'Please select a file'**
+  String get contractUploadEmptyError;
+
+  /// No description provided for @contractViewerTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Review Contract'**
+  String get contractViewerTitle;
+
+  /// No description provided for @contractViewerConfirmButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Next'**
+  String get contractViewerConfirmButton;
+
+  /// No description provided for @inviteCodeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Invite Code'**
+  String get inviteCodeTitle;
+
+  /// No description provided for @inviteCodeHeading.
+  ///
+  /// In en, this message translates to:
+  /// **'Invite code generated!'**
+  String get inviteCodeHeading;
+
+  /// No description provided for @inviteCodeSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Share the code below with your employee'**
+  String get inviteCodeSubtitle;
+
+  /// No description provided for @inviteCodeCopyButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy Code'**
+  String get inviteCodeCopyButton;
+
+  /// No description provided for @inviteCodeCopied.
+  ///
+  /// In en, this message translates to:
+  /// **'Copied to clipboard'**
+  String get inviteCodeCopied;
+
+  /// No description provided for @inviteCodeShareKakao.
+  ///
+  /// In en, this message translates to:
+  /// **'Kakao'**
+  String get inviteCodeShareKakao;
+
+  /// No description provided for @inviteCodeShareLine.
+  ///
+  /// In en, this message translates to:
+  /// **'Line'**
+  String get inviteCodeShareLine;
+
+  /// No description provided for @inviteCodeShareOther.
+  ///
+  /// In en, this message translates to:
+  /// **'Other'**
+  String get inviteCodeShareOther;
+
+  /// No description provided for @inviteCodeDoneButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Done'**
+  String get inviteCodeDoneButton;
+
+  /// No description provided for @inviteCodeShareKakaoButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Share via KakaoTalk'**
+  String get inviteCodeShareKakaoButton;
 
   /// No description provided for @appTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'소상공인'**
+  /// In en, this message translates to:
+  /// **'Small Biz'**
   String get appTitle;
 
   /// No description provided for @confirmButton.
   ///
-  /// In ko, this message translates to:
-  /// **'확인'**
+  /// In en, this message translates to:
+  /// **'Confirm'**
   String get confirmButton;
 
   /// No description provided for @cancelButton.
   ///
-  /// In ko, this message translates to:
-  /// **'취소'**
+  /// In en, this message translates to:
+  /// **'Cancel'**
   String get cancelButton;
 
   /// No description provided for @skipButton.
   ///
-  /// In ko, this message translates to:
-  /// **'나중에 하기'**
+  /// In en, this message translates to:
+  /// **'Skip for now'**
   String get skipButton;
 
   /// No description provided for @agreeButton.
   ///
-  /// In ko, this message translates to:
-  /// **'위 내용에 동의합니다'**
+  /// In en, this message translates to:
+  /// **'I agree to the above'**
   String get agreeButton;
 
   /// No description provided for @newBadge.
   ///
-  /// In ko, this message translates to:
+  /// In en, this message translates to:
   /// **'NEW'**
   String get newBadge;
 
   /// No description provided for @networkError.
   ///
-  /// In ko, this message translates to:
-  /// **'네트워크 오류가 발생했습니다.'**
+  /// In en, this message translates to:
+  /// **'A network error has occurred.'**
   String get networkError;
 
   /// No description provided for @retryButton.
   ///
-  /// In ko, this message translates to:
-  /// **'다시 시도'**
+  /// In en, this message translates to:
+  /// **'Retry'**
   String get retryButton;
 
   /// No description provided for @maintenanceDialogTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'서비스 점검 중'**
+  /// In en, this message translates to:
+  /// **'Under Maintenance'**
   String get maintenanceDialogTitle;
 
   /// No description provided for @maintenanceStartLabel.
   ///
-  /// In ko, this message translates to:
-  /// **'시작'**
+  /// In en, this message translates to:
+  /// **'Start'**
   String get maintenanceStartLabel;
 
   /// No description provided for @maintenanceEndLabel.
   ///
-  /// In ko, this message translates to:
-  /// **'종료'**
+  /// In en, this message translates to:
+  /// **'End'**
   String get maintenanceEndLabel;
 
   /// No description provided for @forceUpdateDialogTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'업데이트 필요'**
+  /// In en, this message translates to:
+  /// **'Update Required'**
   String get forceUpdateDialogTitle;
 
   /// No description provided for @forceUpdateDialogMessage.
   ///
-  /// In ko, this message translates to:
-  /// **'서비스 이용을 위해 최신 버전으로 업데이트해 주세요.'**
+  /// In en, this message translates to:
+  /// **'Please update to the latest version to continue.'**
   String get forceUpdateDialogMessage;
 
   /// No description provided for @optionalUpdateDialogTitle.
   ///
-  /// In ko, this message translates to:
-  /// **'새 버전 안내'**
+  /// In en, this message translates to:
+  /// **'New Version Available'**
   String get optionalUpdateDialogTitle;
 
   /// No description provided for @optionalUpdateDialogMessage.
   ///
-  /// In ko, this message translates to:
-  /// **'더 나은 서비스를 위해 업데이트를 권장합니다.'**
+  /// In en, this message translates to:
+  /// **'We recommend updating for a better experience.'**
   String get optionalUpdateDialogMessage;
 
   /// No description provided for @updateDialogLatestVersion.
   ///
-  /// In ko, this message translates to:
-  /// **'최신 버전: {version}'**
+  /// In en, this message translates to:
+  /// **'Latest version: {version}'**
   String updateDialogLatestVersion(String version);
 
   /// No description provided for @updateButton.
   ///
-  /// In ko, this message translates to:
-  /// **'업데이트'**
+  /// In en, this message translates to:
+  /// **'Update'**
   String get updateButton;
 }
 

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -895,6 +895,126 @@ abstract class S {
   /// **'Share via KakaoTalk'**
   String get inviteCodeShareKakaoButton;
 
+  /// No description provided for @employeeManagementTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Employee Management'**
+  String get employeeManagementTitle;
+
+  /// No description provided for @employeeListEmptyHeading.
+  ///
+  /// In en, this message translates to:
+  /// **'No employees registered'**
+  String get employeeListEmptyHeading;
+
+  /// No description provided for @employeeListEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add employees to get started'**
+  String get employeeListEmptySubtitle;
+
+  /// No description provided for @employeeDetailTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Employee Detail'**
+  String get employeeDetailTitle;
+
+  /// No description provided for @employeeRoleLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Assigned Role'**
+  String get employeeRoleLabel;
+
+  /// No description provided for @employeeStartDateLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Start Date'**
+  String get employeeStartDateLabel;
+
+  /// No description provided for @employeeRoleChangeButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Change Role'**
+  String get employeeRoleChangeButton;
+
+  /// No description provided for @employeeContractRequestButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Request Contract Update'**
+  String get employeeContractRequestButton;
+
+  /// No description provided for @employeeResignButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Process Resignation'**
+  String get employeeResignButton;
+
+  /// No description provided for @employeeRoleChangeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Change Role'**
+  String get employeeRoleChangeTitle;
+
+  /// No description provided for @employeeResignDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Process resignation?'**
+  String get employeeResignDialogTitle;
+
+  /// No description provided for @employeeResignDialogMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'All permissions will be revoked\nand the employee will be marked as resigned.'**
+  String get employeeResignDialogMessage;
+
+  /// No description provided for @employeeStatusActive.
+  ///
+  /// In en, this message translates to:
+  /// **'Active'**
+  String get employeeStatusActive;
+
+  /// No description provided for @employeeStatusResigned.
+  ///
+  /// In en, this message translates to:
+  /// **'Resigned'**
+  String get employeeStatusResigned;
+
+  /// No description provided for @employeeRoleSelectTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Select Role'**
+  String get employeeRoleSelectTitle;
+
+  /// No description provided for @employeeRoleSelectHeading.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a role to assign to the employee'**
+  String get employeeRoleSelectHeading;
+
+  /// No description provided for @employeeRoleSelectSearchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search roles'**
+  String get employeeRoleSelectSearchHint;
+
+  /// No description provided for @employeeRoleSelectEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No results found'**
+  String get employeeRoleSelectEmpty;
+
+  /// No description provided for @employeeRoleSelectNoRole.
+  ///
+  /// In en, this message translates to:
+  /// **'Can\'t find the right role?'**
+  String get employeeRoleSelectNoRole;
+
+  /// No description provided for @employeeRoleSelectCreateButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Create New Role'**
+  String get employeeRoleSelectCreateButton;
+
   /// No description provided for @appTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -432,6 +432,68 @@ class SEn extends S {
   String get inviteCodeShareKakaoButton => 'Share via KakaoTalk';
 
   @override
+  String get employeeManagementTitle => 'Employee Management';
+
+  @override
+  String get employeeListEmptyHeading => 'No employees registered';
+
+  @override
+  String get employeeListEmptySubtitle => 'Add employees to get started';
+
+  @override
+  String get employeeDetailTitle => 'Employee Detail';
+
+  @override
+  String get employeeRoleLabel => 'Assigned Role';
+
+  @override
+  String get employeeStartDateLabel => 'Start Date';
+
+  @override
+  String get employeeRoleChangeButton => 'Change Role';
+
+  @override
+  String get employeeContractRequestButton => 'Request Contract Update';
+
+  @override
+  String get employeeResignButton => 'Process Resignation';
+
+  @override
+  String get employeeRoleChangeTitle => 'Change Role';
+
+  @override
+  String get employeeResignDialogTitle => 'Process resignation?';
+
+  @override
+  String get employeeResignDialogMessage =>
+      'All permissions will be revoked\nand the employee will be marked as resigned.';
+
+  @override
+  String get employeeStatusActive => 'Active';
+
+  @override
+  String get employeeStatusResigned => 'Resigned';
+
+  @override
+  String get employeeRoleSelectTitle => 'Select Role';
+
+  @override
+  String get employeeRoleSelectHeading =>
+      'Select a role to assign to the employee';
+
+  @override
+  String get employeeRoleSelectSearchHint => 'Search roles';
+
+  @override
+  String get employeeRoleSelectEmpty => 'No results found';
+
+  @override
+  String get employeeRoleSelectNoRole => 'Can\'t find the right role?';
+
+  @override
+  String get employeeRoleSelectCreateButton => 'Create New Role';
+
+  @override
   String get appTitle => 'Small Biz';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -255,6 +255,183 @@ class SEn extends S {
   String get noNotices => 'No notices available.';
 
   @override
+  String get roleManagementMenuLabel => 'Role Management';
+
+  @override
+  String get employeeAddMenuLabel => 'Add Employee';
+
+  @override
+  String get roleManagementTitle => 'Role Management';
+
+  @override
+  String get roleAddTitle => 'Add Role';
+
+  @override
+  String get rolePermissionTitle => 'Permission Settings';
+
+  @override
+  String get roleDetailTitle => 'Role Detail';
+
+  @override
+  String get roleEmptyStateHeading => 'Create your first role';
+
+  @override
+  String get roleEmptyStateSubtitle =>
+      'Set up roles before inviting employees\nto manage permissions easily.';
+
+  @override
+  String get roleEmptyStateButton => 'Get Started';
+
+  @override
+  String get roleAddStepOneHeading => 'What kind of role?';
+
+  @override
+  String get roleAddStepOneSubtitle =>
+      'Default permissions will be set based on the role type.';
+
+  @override
+  String get roleTypeManager => 'Manager';
+
+  @override
+  String get roleTypePartTimer => 'Part-timer';
+
+  @override
+  String get roleTypeEmployee => 'Employee';
+
+  @override
+  String get roleTypeNewRole => 'Create New Role';
+
+  @override
+  String get roleNameLabel => 'Role Name';
+
+  @override
+  String get roleNameHint => 'e.g. Weekend Manager';
+
+  @override
+  String get rolePermissionLabel => 'Permissions';
+
+  @override
+  String get roleNextButton => 'Next';
+
+  @override
+  String get roleSaveButton => 'Save';
+
+  @override
+  String get roleCompleteButton => 'Done';
+
+  @override
+  String get roleDeleteButton => 'Delete';
+
+  @override
+  String get roleDeleteDialogTitle => 'Delete this role?';
+
+  @override
+  String get roleDeleteDialogMessage =>
+      'Employees assigned to this role\nmay have their role removed.';
+
+  @override
+  String get permissionStaffManage => 'Staff Management';
+
+  @override
+  String get permissionStaffManageDesc => 'Register and manage employees';
+
+  @override
+  String get permissionStoreManage => 'Store Management';
+
+  @override
+  String get permissionStoreManageDesc => 'View and edit store information';
+
+  @override
+  String get permissionContractManage => 'Contract Management';
+
+  @override
+  String get permissionContractManageDesc => 'Register and review contracts';
+
+  @override
+  String get permissionSalaryManage => 'Payroll';
+
+  @override
+  String get permissionSalaryManageDesc => 'View and manage payroll';
+
+  @override
+  String get permissionStaffInvite => 'Invite Staff';
+
+  @override
+  String get permissionStaffInviteDesc => 'Generate and share invite codes';
+
+  @override
+  String get contractMethodTitle => 'Employment Contract';
+
+  @override
+  String get contractMethodHeading => 'How would you like to register?';
+
+  @override
+  String get contractMethodDirectLabel => 'Upload PDF';
+
+  @override
+  String get contractMethodDirectDesc => 'Upload a PDF file directly';
+
+  @override
+  String get contractMethodTemplateLabel => 'Load Template';
+
+  @override
+  String get contractMethodTemplateDesc => 'Coming soon';
+
+  @override
+  String get contractUploadTitle => 'Employment Contract';
+
+  @override
+  String get contractUploadHeading => 'Please upload the contract';
+
+  @override
+  String get contractUploadSubtitle => 'Only PDF files are supported';
+
+  @override
+  String get contractUploadButton => 'Select File';
+
+  @override
+  String get contractUploadNextButton => 'Next';
+
+  @override
+  String get contractUploadEmptyError => 'Please select a file';
+
+  @override
+  String get contractViewerTitle => 'Review Contract';
+
+  @override
+  String get contractViewerConfirmButton => 'Next';
+
+  @override
+  String get inviteCodeTitle => 'Invite Code';
+
+  @override
+  String get inviteCodeHeading => 'Invite code generated!';
+
+  @override
+  String get inviteCodeSubtitle => 'Share the code below with your employee';
+
+  @override
+  String get inviteCodeCopyButton => 'Copy Code';
+
+  @override
+  String get inviteCodeCopied => 'Copied to clipboard';
+
+  @override
+  String get inviteCodeShareKakao => 'Kakao';
+
+  @override
+  String get inviteCodeShareLine => 'Line';
+
+  @override
+  String get inviteCodeShareOther => 'Other';
+
+  @override
+  String get inviteCodeDoneButton => 'Done';
+
+  @override
+  String get inviteCodeShareKakaoButton => 'Share via KakaoTalk';
+
+  @override
   String get appTitle => 'Small Biz';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -411,6 +411,66 @@ class SKo extends S {
   String get inviteCodeShareKakaoButton => '카카오톡으로 공유하기';
 
   @override
+  String get employeeManagementTitle => '직원 관리';
+
+  @override
+  String get employeeListEmptyHeading => '등록된 직원이 없어요';
+
+  @override
+  String get employeeListEmptySubtitle => '직원을 추가하고 관리해보세요';
+
+  @override
+  String get employeeDetailTitle => '직원 상세';
+
+  @override
+  String get employeeRoleLabel => '부여 역할';
+
+  @override
+  String get employeeStartDateLabel => '근무 시작일';
+
+  @override
+  String get employeeRoleChangeButton => '직원 롤 변경';
+
+  @override
+  String get employeeContractRequestButton => '근로계약서 수정 요청';
+
+  @override
+  String get employeeResignButton => '퇴직 처리';
+
+  @override
+  String get employeeRoleChangeTitle => '롤 변경';
+
+  @override
+  String get employeeResignDialogTitle => '퇴직 처리하시겠습니까?';
+
+  @override
+  String get employeeResignDialogMessage => '이 직원의 모든 권한이 해제되고\n퇴직 처리됩니다.';
+
+  @override
+  String get employeeStatusActive => '재직중';
+
+  @override
+  String get employeeStatusResigned => '퇴직';
+
+  @override
+  String get employeeRoleSelectTitle => '역할 선택';
+
+  @override
+  String get employeeRoleSelectHeading => '직원에게 할당할 역할을 선택해주세요';
+
+  @override
+  String get employeeRoleSelectSearchHint => '역할 검색';
+
+  @override
+  String get employeeRoleSelectEmpty => '검색 결과가 없어요';
+
+  @override
+  String get employeeRoleSelectNoRole => '알맞은 역할이 없다면?';
+
+  @override
+  String get employeeRoleSelectCreateButton => '새 역할 만들기';
+
+  @override
   String get appTitle => '소상공인';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -237,6 +237,180 @@ class SKo extends S {
   String get noNotices => '등록된 공지사항이 없습니다.';
 
   @override
+  String get roleManagementMenuLabel => '역할 관리';
+
+  @override
+  String get employeeAddMenuLabel => '직원 추가';
+
+  @override
+  String get roleManagementTitle => '역할 관리';
+
+  @override
+  String get roleAddTitle => '역할 추가';
+
+  @override
+  String get rolePermissionTitle => '권한 설정';
+
+  @override
+  String get roleDetailTitle => '역할 상세';
+
+  @override
+  String get roleEmptyStateHeading => '역할을 만들어보세요';
+
+  @override
+  String get roleEmptyStateSubtitle => '직원을 초대하기 전 역할을 먼저 설정하면\n권한 관리가 편리해져요';
+
+  @override
+  String get roleEmptyStateButton => '시작하기';
+
+  @override
+  String get roleAddStepOneHeading => '어떤 역할을 만들까요?';
+
+  @override
+  String get roleAddStepOneSubtitle => '역할 유형을 선택하면 기본 권한이 설정돼요';
+
+  @override
+  String get roleTypeManager => '매니저';
+
+  @override
+  String get roleTypePartTimer => '파트타이머';
+
+  @override
+  String get roleTypeEmployee => '직원';
+
+  @override
+  String get roleTypeNewRole => '새 역할 만들기';
+
+  @override
+  String get roleNameLabel => '역할 이름';
+
+  @override
+  String get roleNameHint => '예) 주말 매니저';
+
+  @override
+  String get rolePermissionLabel => '권한 설정';
+
+  @override
+  String get roleNextButton => '다음';
+
+  @override
+  String get roleSaveButton => '저장';
+
+  @override
+  String get roleCompleteButton => '완료';
+
+  @override
+  String get roleDeleteButton => '삭제';
+
+  @override
+  String get roleDeleteDialogTitle => '역할을 삭제하시겠어요?';
+
+  @override
+  String get roleDeleteDialogMessage => '이 역할에 배정된 직원이 있다면\n역할이 해제될 수 있어요.';
+
+  @override
+  String get permissionStaffManage => '직원 관리';
+
+  @override
+  String get permissionStaffManageDesc => '직원 등록 및 관리';
+
+  @override
+  String get permissionStoreManage => '매장 관리';
+
+  @override
+  String get permissionStoreManageDesc => '매장 정보 조회 및 수정';
+
+  @override
+  String get permissionContractManage => '근로계약서 관리';
+
+  @override
+  String get permissionContractManageDesc => '근로계약서 등록 및 확인';
+
+  @override
+  String get permissionSalaryManage => '급여 관리';
+
+  @override
+  String get permissionSalaryManageDesc => '급여 조회 및 관리';
+
+  @override
+  String get permissionStaffInvite => '직원 초대';
+
+  @override
+  String get permissionStaffInviteDesc => '초대코드 생성 및 공유';
+
+  @override
+  String get contractMethodTitle => '근로계약서 등록';
+
+  @override
+  String get contractMethodHeading => '어떤 방식으로 등록할까요?';
+
+  @override
+  String get contractMethodDirectLabel => 'PDF 직접 업로드';
+
+  @override
+  String get contractMethodDirectDesc => 'PDF 파일을 직접 업로드해요';
+
+  @override
+  String get contractMethodTemplateLabel => '템플릿 불러오기';
+
+  @override
+  String get contractMethodTemplateDesc => '준비 중입니다';
+
+  @override
+  String get contractUploadTitle => '근로계약서 등록';
+
+  @override
+  String get contractUploadHeading => '근로계약서를 업로드해주세요';
+
+  @override
+  String get contractUploadSubtitle => 'PDF 파일만 업로드 가능해요';
+
+  @override
+  String get contractUploadButton => '파일 선택';
+
+  @override
+  String get contractUploadNextButton => '다음';
+
+  @override
+  String get contractUploadEmptyError => '파일을 선택해주세요';
+
+  @override
+  String get contractViewerTitle => '계약서 확인';
+
+  @override
+  String get contractViewerConfirmButton => '다음';
+
+  @override
+  String get inviteCodeTitle => '초대 코드';
+
+  @override
+  String get inviteCodeHeading => '초대 코드가 생성됐어요!';
+
+  @override
+  String get inviteCodeSubtitle => '아래 코드를 직원에게 공유해주세요';
+
+  @override
+  String get inviteCodeCopyButton => '코드 복사';
+
+  @override
+  String get inviteCodeCopied => '클립보드에 복사됐어요';
+
+  @override
+  String get inviteCodeShareKakao => '카카오';
+
+  @override
+  String get inviteCodeShareLine => '라인';
+
+  @override
+  String get inviteCodeShareOther => '기타';
+
+  @override
+  String get inviteCodeDoneButton => '완료';
+
+  @override
+  String get inviteCodeShareKakaoButton => '카카오톡으로 공유하기';
+
+  @override
   String get appTitle => '소상공인';
 
   @override

--- a/lib/l10n/src/employee_en.arb
+++ b/lib/l10n/src/employee_en.arb
@@ -1,0 +1,55 @@
+{
+  "@@locale": "en",
+
+  "contractMethodTitle": "Employment Contract",
+  "contractMethodHeading": "How would you like to register?",
+  "contractMethodDirectLabel": "Upload PDF",
+  "contractMethodDirectDesc": "Upload a PDF file directly",
+  "contractMethodTemplateLabel": "Load Template",
+  "contractMethodTemplateDesc": "Coming soon",
+
+  "contractUploadTitle": "Employment Contract",
+  "contractUploadHeading": "Please upload the contract",
+  "contractUploadSubtitle": "Only PDF files are supported",
+  "contractUploadButton": "Select File",
+  "contractUploadNextButton": "Next",
+  "contractUploadEmptyError": "Please select a file",
+
+  "contractViewerTitle": "Review Contract",
+  "contractViewerConfirmButton": "Next",
+
+  "inviteCodeTitle": "Invite Code",
+  "inviteCodeHeading": "Invite code generated!",
+  "inviteCodeSubtitle": "Share the code below with your employee",
+  "inviteCodeCopyButton": "Copy Code",
+  "inviteCodeCopied": "Copied to clipboard",
+  "inviteCodeShareKakao": "Kakao",
+  "inviteCodeShareLine": "Line",
+  "inviteCodeShareOther": "Other",
+  "inviteCodeDoneButton": "Done",
+  "inviteCodeShareKakaoButton": "Share via KakaoTalk",
+
+  "employeeManagementTitle": "Employee Management",
+  "employeeListEmptyHeading": "No employees registered",
+  "employeeListEmptySubtitle": "Add employees to get started",
+
+  "employeeDetailTitle": "Employee Detail",
+  "employeeRoleLabel": "Assigned Role",
+  "employeeStartDateLabel": "Start Date",
+  "employeeRoleChangeButton": "Change Role",
+  "employeeContractRequestButton": "Request Contract Update",
+  "employeeResignButton": "Process Resignation",
+
+  "employeeRoleChangeTitle": "Change Role",
+  "employeeResignDialogTitle": "Process resignation?",
+  "employeeResignDialogMessage": "All permissions will be revoked\nand the employee will be marked as resigned.",
+  "employeeStatusActive": "Active",
+  "employeeStatusResigned": "Resigned",
+
+  "employeeRoleSelectTitle": "Select Role",
+  "employeeRoleSelectHeading": "Select a role to assign to the employee",
+  "employeeRoleSelectSearchHint": "Search roles",
+  "employeeRoleSelectEmpty": "No results found",
+  "employeeRoleSelectNoRole": "Can't find the right role?",
+  "employeeRoleSelectCreateButton": "Create New Role"
+}

--- a/lib/l10n/src/employee_ko.arb
+++ b/lib/l10n/src/employee_ko.arb
@@ -1,0 +1,55 @@
+{
+  "@@locale": "ko",
+
+  "contractMethodTitle": "근로계약서 등록",
+  "contractMethodHeading": "어떤 방식으로 등록할까요?",
+  "contractMethodDirectLabel": "PDF 직접 업로드",
+  "contractMethodDirectDesc": "PDF 파일을 직접 업로드해요",
+  "contractMethodTemplateLabel": "템플릿 불러오기",
+  "contractMethodTemplateDesc": "준비 중입니다",
+
+  "contractUploadTitle": "근로계약서 등록",
+  "contractUploadHeading": "근로계약서를 업로드해주세요",
+  "contractUploadSubtitle": "PDF 파일만 업로드 가능해요",
+  "contractUploadButton": "파일 선택",
+  "contractUploadNextButton": "다음",
+  "contractUploadEmptyError": "파일을 선택해주세요",
+
+  "contractViewerTitle": "계약서 확인",
+  "contractViewerConfirmButton": "다음",
+
+  "inviteCodeTitle": "초대 코드",
+  "inviteCodeHeading": "초대 코드가 생성됐어요!",
+  "inviteCodeSubtitle": "아래 코드를 직원에게 공유해주세요",
+  "inviteCodeCopyButton": "코드 복사",
+  "inviteCodeCopied": "클립보드에 복사됐어요",
+  "inviteCodeShareKakao": "카카오",
+  "inviteCodeShareLine": "라인",
+  "inviteCodeShareOther": "기타",
+  "inviteCodeDoneButton": "완료",
+  "inviteCodeShareKakaoButton": "카카오톡으로 공유하기",
+
+  "employeeManagementTitle": "직원 관리",
+  "employeeListEmptyHeading": "등록된 직원이 없어요",
+  "employeeListEmptySubtitle": "직원을 추가하고 관리해보세요",
+
+  "employeeDetailTitle": "직원 상세",
+  "employeeRoleLabel": "부여 역할",
+  "employeeStartDateLabel": "근무 시작일",
+  "employeeRoleChangeButton": "직원 롤 변경",
+  "employeeContractRequestButton": "근로계약서 수정 요청",
+  "employeeResignButton": "퇴직 처리",
+
+  "employeeRoleChangeTitle": "롤 변경",
+  "employeeResignDialogTitle": "퇴직 처리하시겠습니까?",
+  "employeeResignDialogMessage": "이 직원의 모든 권한이 해제되고\n퇴직 처리됩니다.",
+  "employeeStatusActive": "재직중",
+  "employeeStatusResigned": "퇴직",
+
+  "employeeRoleSelectTitle": "역할 선택",
+  "employeeRoleSelectHeading": "직원에게 할당할 역할을 선택해주세요",
+  "employeeRoleSelectSearchHint": "역할 검색",
+  "employeeRoleSelectEmpty": "검색 결과가 없어요",
+  "employeeRoleSelectNoRole": "알맞은 역할이 없다면?",
+  "employeeRoleSelectCreateButton": "새 역할 만들기"
+}

--- a/lib/l10n/src/home_en.arb
+++ b/lib/l10n/src/home_en.arb
@@ -6,5 +6,7 @@
   "noticesHeaderTitle": "Notices",
   "myPageHeaderTitle": "My Page",
   "viewProfileLink": "View profile",
-  "noNotices": "No notices available."
+  "noNotices": "No notices available.",
+  "roleManagementMenuLabel": "Role Management",
+  "employeeAddMenuLabel": "Add Employee"
 }

--- a/lib/l10n/src/home_ko.arb
+++ b/lib/l10n/src/home_ko.arb
@@ -6,5 +6,7 @@
   "noticesHeaderTitle": "공지사항",
   "myPageHeaderTitle": "마이페이지",
   "viewProfileLink": "프로필 보기",
-  "noNotices": "등록된 공지사항이 없습니다."
+  "noNotices": "등록된 공지사항이 없습니다.",
+  "roleManagementMenuLabel": "역할 관리",
+  "employeeAddMenuLabel": "직원 추가"
 }

--- a/lib/l10n/src/role_en.arb
+++ b/lib/l10n/src/role_en.arb
@@ -1,0 +1,43 @@
+{
+  "@@locale": "en",
+
+  "roleManagementTitle": "Role Management",
+  "roleAddTitle": "Add Role",
+  "rolePermissionTitle": "Permission Settings",
+  "roleDetailTitle": "Role Detail",
+
+  "roleEmptyStateHeading": "Create your first role",
+  "roleEmptyStateSubtitle": "Set up roles before inviting employees\nto manage permissions easily.",
+  "roleEmptyStateButton": "Get Started",
+
+  "roleAddStepOneHeading": "What kind of role?",
+  "roleAddStepOneSubtitle": "Default permissions will be set based on the role type.",
+
+  "roleTypeManager": "Manager",
+  "roleTypePartTimer": "Part-timer",
+  "roleTypeEmployee": "Employee",
+  "roleTypeNewRole": "Create New Role",
+
+  "roleNameLabel": "Role Name",
+  "roleNameHint": "e.g. Weekend Manager",
+  "rolePermissionLabel": "Permissions",
+
+  "roleNextButton": "Next",
+  "roleSaveButton": "Save",
+  "roleCompleteButton": "Done",
+  "roleDeleteButton": "Delete",
+
+  "roleDeleteDialogTitle": "Delete this role?",
+  "roleDeleteDialogMessage": "Employees assigned to this role\nmay have their role removed.",
+
+  "permissionStaffManage": "Staff Management",
+  "permissionStaffManageDesc": "Register and manage employees",
+  "permissionStoreManage": "Store Management",
+  "permissionStoreManageDesc": "View and edit store information",
+  "permissionContractManage": "Contract Management",
+  "permissionContractManageDesc": "Register and review contracts",
+  "permissionSalaryManage": "Payroll",
+  "permissionSalaryManageDesc": "View and manage payroll",
+  "permissionStaffInvite": "Invite Staff",
+  "permissionStaffInviteDesc": "Generate and share invite codes"
+}

--- a/lib/l10n/src/role_ko.arb
+++ b/lib/l10n/src/role_ko.arb
@@ -1,0 +1,43 @@
+{
+  "@@locale": "ko",
+
+  "roleManagementTitle": "역할 관리",
+  "roleAddTitle": "역할 추가",
+  "rolePermissionTitle": "권한 설정",
+  "roleDetailTitle": "역할 상세",
+
+  "roleEmptyStateHeading": "역할을 만들어보세요",
+  "roleEmptyStateSubtitle": "직원을 초대하기 전 역할을 먼저 설정하면\n권한 관리가 편리해져요",
+  "roleEmptyStateButton": "시작하기",
+
+  "roleAddStepOneHeading": "어떤 역할을 만들까요?",
+  "roleAddStepOneSubtitle": "역할 유형을 선택하면 기본 권한이 설정돼요",
+
+  "roleTypeManager": "매니저",
+  "roleTypePartTimer": "파트타이머",
+  "roleTypeEmployee": "직원",
+  "roleTypeNewRole": "새 역할 만들기",
+
+  "roleNameLabel": "역할 이름",
+  "roleNameHint": "예) 주말 매니저",
+  "rolePermissionLabel": "권한 설정",
+
+  "roleNextButton": "다음",
+  "roleSaveButton": "저장",
+  "roleCompleteButton": "완료",
+  "roleDeleteButton": "삭제",
+
+  "roleDeleteDialogTitle": "역할을 삭제하시겠어요?",
+  "roleDeleteDialogMessage": "이 역할에 배정된 직원이 있다면\n역할이 해제될 수 있어요.",
+
+  "permissionStaffManage": "직원 관리",
+  "permissionStaffManageDesc": "직원 등록 및 관리",
+  "permissionStoreManage": "매장 관리",
+  "permissionStoreManageDesc": "매장 정보 조회 및 수정",
+  "permissionContractManage": "근로계약서 관리",
+  "permissionContractManageDesc": "근로계약서 등록 및 확인",
+  "permissionSalaryManage": "급여 관리",
+  "permissionSalaryManageDesc": "급여 조회 및 관리",
+  "permissionStaffInvite": "직원 초대",
+  "permissionStaffInviteDesc": "초대코드 생성 및 공유"
+}

--- a/merge_arb.dart
+++ b/merge_arb.dart
@@ -30,6 +30,8 @@ void main() {
     'consent',
     'account',
     'home',
+    'role',
+    'employee',
     'common', // 공통 (버튼, 에러 메시지 등)
   ];
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -185,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -281,6 +289,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.7"
   firebase_core:
     dependency: "direct main"
     description:
@@ -379,6 +395,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_pdfview:
+    dependency: "direct main"
+    description:
+      name: flutter_pdfview
+      sha256: "5b80e89f3ba6e478d1e897543c9634508284ad73476807febc188378986b69ee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.4"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.34"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -837,6 +869,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  qr_flutter:
+    dependency: "direct main"
+    description:
+      name: qr_flutter
+      sha256: "5095f0fc6e3f71d08adef8feccc8cea4f12eec18a2e31c2e8d82cb6019f4b097"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   riverpod:
     dependency: transitive
     description:
@@ -869,6 +917,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.5"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   shared_preferences:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,14 +20,17 @@ dependencies:
   cupertino_icons: ^1.0.8
   firebase_core: ^3.13.0
   firebase_messaging: ^15.2.10
-  # HTTP보다 강력한 기능을 제공하는 Dio로 교체
   dio: ^5.7.0
   json_annotation: ^4.9.0
   flutter_local_notifications: ^18.0.0
-  flutter_secure_storage: ^9.2.2  # 토큰 저장용
-  kakao_flutter_sdk_user: ^1.9.0  # 카카오 로그인용
+  flutter_secure_storage: ^9.2.2
+  kakao_flutter_sdk_user: ^1.9.0
   url_launcher: ^6.3.0
   package_info_plus: ^8.0.0
+  flutter_pdfview: ^1.3.2
+  file_picker: ^8.1.2
+  qr_flutter: ^4.1.0
+  share_plus: ^10.0.0
 
 dev_dependencies:
   flutter_test:

--- a/test/routing_test.dart
+++ b/test/routing_test.dart
@@ -13,9 +13,19 @@ import 'package:sosangongin_platform/features/home/notice_detail_screen.dart';
 import 'package:sosangongin_platform/features/home/notice_provider.dart';
 import 'package:sosangongin_platform/features/home/notices_screen.dart';
 import 'package:sosangongin_platform/features/splash/splash_screen.dart';
+import 'package:sosangongin_platform/features/role/role_add_screen.dart';
+import 'package:sosangongin_platform/features/role/role_detail_screen.dart';
+import 'package:sosangongin_platform/features/role/role_list_screen.dart';
+import 'package:sosangongin_platform/features/role/role_provider.dart';
+import 'package:sosangongin_platform/features/employee/add/contract_method_screen.dart';
+import 'package:sosangongin_platform/features/employee/add/invite_code_screen.dart';
+import 'package:sosangongin_platform/features/employee/employee_detail_screen.dart';
+import 'package:sosangongin_platform/features/employee/employee_list_screen.dart';
+import 'package:sosangongin_platform/features/employee/employee_provider.dart';
+import 'package:sosangongin_platform/features/employee/employee_role_select_screen.dart';
 import 'package:sosangongin_platform/l10n/app_localizations.dart';
 
-// 헬퍼
+// ── 헬퍼 ─────────────────────────────────────────────────
 
 GoRouter _buildTestRouter(String initialLocation) {
   return GoRouter(
@@ -64,6 +74,40 @@ GoRouter _buildTestRouter(String initialLocation) {
         builder: (context, state) =>
             NoticeDetailScreen(notice: state.extra as Notice),
       ),
+      GoRoute(
+        path: '/role',
+        builder: (context, state) => const RoleListScreen(),
+      ),
+      GoRoute(
+        path: '/role/add',
+        builder: (context, state) => const RoleAddScreen(),
+      ),
+      GoRoute(
+        path: '/role/detail',
+        builder: (context, state) =>
+            RoleDetailScreen(role: state.extra as RoleModel),
+      ),
+      GoRoute(
+        path: '/employee',
+        builder: (context, state) => const EmployeeListScreen(),
+      ),
+      GoRoute(
+        path: '/employee/detail',
+        builder: (context, state) =>
+            EmployeeDetailScreen(employee: state.extra as EmployeeModel),
+      ),
+      GoRoute(
+        path: '/employee/add/role-select',
+        builder: (context, state) => const EmployeeRoleSelectScreen(),
+      ),
+      GoRoute(
+        path: '/employee/add/contract-method',
+        builder: (context, state) => const ContractMethodScreen(),
+      ),
+      GoRoute(
+        path: '/employee/add/invite-code',
+        builder: (context, state) => const InviteCodeScreen(),
+      ),
     ],
   );
 }
@@ -79,7 +123,8 @@ Widget _buildTestApp(GoRouter router) {
   );
 }
 
-// Notice 모델이 notice_provider.dart로 이동됨
+// Mock 데이터
+
 final _mockNotice = Notice(
   id: 1,
   title: '정기 휴무일 안내',
@@ -90,7 +135,22 @@ final _mockNotice = Notice(
   createdAt: DateTime.now().toIso8601String(),
 );
 
-// ── 화면 렌더링 테스트 ─────────────────────────────────────
+final _mockRole = RoleModel(
+  id: 1,
+  name: '매니저',
+  description: 'manager',
+  permissions: const [],
+);
+
+final _mockEmployee = EmployeeModel(
+  id: 'emp_001',
+  name: '김민수',
+  role: _mockRole,
+  startDate: '2024.01.01',
+  status: EmployeeStatus.active,
+);
+
+// ── 화면 렌더링 테스트 ────────────────────────────────────
 
 void main() {
   group('화면 렌더링', () {
@@ -180,9 +240,84 @@ void main() {
       );
       await tester.pumpWidget(_buildTestApp(router));
       await tester.pumpAndSettle();
-
       expect(find.byType(NoticeDetailScreen), findsOneWidget);
       expect(find.text('정기 휴무일 안내'), findsOneWidget);
+    });
+
+    testWidgets('역할 목록', (tester) async {
+      final router = _buildTestRouter('/role');
+      await tester.pumpWidget(_buildTestApp(router));
+      await tester.pumpAndSettle();
+      expect(find.byType(RoleListScreen), findsOneWidget);
+    });
+
+    testWidgets('역할 추가', (tester) async {
+      final router = _buildTestRouter('/role/add');
+      await tester.pumpWidget(_buildTestApp(router));
+      await tester.pumpAndSettle();
+      expect(find.byType(RoleAddScreen), findsOneWidget);
+    });
+
+    testWidgets('역할 상세', (tester) async {
+      final router = GoRouter(
+        initialLocation: '/role/detail',
+        initialExtra: _mockRole,
+        routes: [
+          GoRoute(
+            path: '/role/detail',
+            builder: (context, state) =>
+                RoleDetailScreen(role: state.extra as RoleModel),
+          ),
+        ],
+      );
+      await tester.pumpWidget(_buildTestApp(router));
+      await tester.pumpAndSettle();
+      expect(find.byType(RoleDetailScreen), findsOneWidget);
+    });
+
+    testWidgets('직원 목록', (tester) async {
+      final router = _buildTestRouter('/employee');
+      await tester.pumpWidget(_buildTestApp(router));
+      await tester.pumpAndSettle();
+      expect(find.byType(EmployeeListScreen), findsOneWidget);
+    });
+
+    testWidgets('직원 상세', (tester) async {
+      final router = GoRouter(
+        initialLocation: '/employee/detail',
+        initialExtra: _mockEmployee,
+        routes: [
+          GoRoute(
+            path: '/employee/detail',
+            builder: (context, state) =>
+                EmployeeDetailScreen(employee: state.extra as EmployeeModel),
+          ),
+        ],
+      );
+      await tester.pumpWidget(_buildTestApp(router));
+      await tester.pumpAndSettle();
+      expect(find.byType(EmployeeDetailScreen), findsOneWidget);
+    });
+
+    testWidgets('역할 선택', (tester) async {
+      final router = _buildTestRouter('/employee/add/role-select');
+      await tester.pumpWidget(_buildTestApp(router));
+      await tester.pumpAndSettle();
+      expect(find.byType(EmployeeRoleSelectScreen), findsOneWidget);
+    });
+
+    testWidgets('계약방식 선택', (tester) async {
+      final router = _buildTestRouter('/employee/add/contract-method');
+      await tester.pumpWidget(_buildTestApp(router));
+      await tester.pumpAndSettle();
+      expect(find.byType(ContractMethodScreen), findsOneWidget);
+    });
+
+    testWidgets('초대코드', (tester) async {
+      final router = _buildTestRouter('/employee/add/invite-code');
+      await tester.pumpWidget(_buildTestApp(router));
+      await tester.pumpAndSettle();
+      expect(find.byType(InviteCodeScreen), findsOneWidget);
     });
   });
 
@@ -210,6 +345,39 @@ void main() {
       await tester.pumpWidget(_buildTestApp(router));
       await tester.pumpAndSettle();
       expect(find.text('나중에 하기'), findsNothing);
+    });
+  });
+
+  // 역할 관리 첫 진입 분기
+
+  group('역할 관리 첫 진입 분기', () {
+    testWidgets('역할 없을 때 — empty state 노출', (tester) async {
+      // roleListProvider를 빈 목록으로 override
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            roleListProvider.overrideWith(
+                  (ref) => RoleListNotifier()..state = const AsyncData([]),
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: S.localizationsDelegates,
+            supportedLocales: S.supportedLocales,
+            locale: const Locale('ko'),
+            home: const Scaffold(body: RoleListScreen()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('역할을 만들어보세요'), findsOneWidget);
+    });
+
+    testWidgets('역할 있을 때 — 목록 노출', (tester) async {
+      final router = _buildTestRouter('/role');
+      await tester.pumpWidget(_buildTestApp(router));
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+      expect(find.text('역할을 만들어보세요'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
역할 관리 및 직원 관리 UI 구현

API 연동은 별도 이슈로 분리 예정이며, 현재는 Mock 데이터 기반으로 동작합니다.


역할 관리
- 역할 목록 / 추가(유형 선택 → 권한 설정) / 상세 화면 구현
- 역할 유형 선택 시 기본 권한 프리셋 자동 적용
- 권한 토글 수정 및 역할 삭제 기능

직원 관리
- 직원 목록 / 상세 화면 구현
- 직원 상세에서 역할 변경(바텀시트), 퇴직 처리(다이얼로그) 기능

직원 추가 플로우
- 역할 검색 및 선택 → PDF 계약서 업로드 → 뷰어 확인 → 초대코드 생성/공유
- 역할이 없을 경우 역할 추가 화면으로 이동 후 복귀 처리
- 템플릿 불러오기는 준비 중으로 비활성 처리

테스트
- 신규 화면 렌더링 테스트 추가
- 역할 관리 첫 진입 분기 테스트 추가
